### PR TITLE
Support 'seek' and 'rsize' options

### DIFF
--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -74,9 +74,10 @@ static struct list_head readers = LIST_INIT(readers);
 static struct list_head writers = LIST_INIT(writers);
 
 static ssize_t tftp_send_data(struct tftp_client *client,
-			      unsigned int block, size_t offset)
+			      unsigned int block, size_t offset, size_t response_size)
 {
 	ssize_t len;
+	size_t send_len;
 	char *buf;
 	char *p;
 
@@ -98,8 +99,21 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 
 	p += len;
 
-	// printf("[TQFTP] Sending %zd bytes of DATA\n", p - buf);
-	len = send(client->sock, buf, p - buf, 0);
+	/* If rsize was set, we should limit the data in the response to n bytes */
+	if (response_size != 0) {
+		/* Header (4 bytes) + data size */
+		send_len = 4 + response_size;
+		if (send_len > p - buf) {
+			printf("[TQFTP] requested data of %ld bytes but only read %ld bytes from file, rejecting\n", response_size, len);
+			free(buf);
+			return -EINVAL;
+		}
+	} else {
+		send_len = p - buf;
+	}
+
+	// printf("[TQFTP] Sending %zd bytes of DATA\n", send_len);
+	len = send(client->sock, buf, send_len, 0);
 
 	free(buf);
 
@@ -336,7 +350,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 			       rsize ? &rsize : NULL,
 			       seek ? &seek : NULL);
 	} else {
-		tftp_send_data(client, 1, 0);
+		tftp_send_data(client, 1, 0, 0);
 	}
 }
 
@@ -418,7 +432,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 			       rsize ? &rsize : NULL,
 			       seek ? &seek : NULL);
 	} else {
-		tftp_send_data(client, 1, 0);
+		tftp_send_data(client, 1, 0, 0);
 	}
 }
 
@@ -463,15 +477,28 @@ static int handle_reader(struct tftp_client *client)
 	last = buf[2] << 8 | buf[3];
 	// printf("[TQFTP] Got ack for %d\n", last);
 
+	/* We've sent enough data for rsize already */
+	if (last * client->blksize > client->rsize)
+		return 0;
+
 	for (block = last; block < last + client->wsize; block++) {
+		size_t offset = client->seek + block * client->blksize;
+		size_t response_size = 0;
+		/* Check if need to limit response size based for requested rsize */
+		if ((block + 1) * client->blksize > client->rsize)
+			response_size = client->rsize % client->blksize;
+
 		n = tftp_send_data(client, block + 1,
-				   block * client->blksize);
+				   offset, response_size);
 		if (n < 0) {
 			printf("[TQFTP] Sent block %d failed: %zd\n", block + 1, n);
 			break;
 		}
 		// printf("[TQFTP] Sent block %d of %zd\n", block + 1, n);
 		if (n == 0)
+			break;
+		/* We've sent enough data for rsize already */
+		if ((block + 1) * client->blksize > client->rsize)
 			break;
 	}
 

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -53,6 +53,10 @@ enum {
 	OP_OACK,
 };
 
+enum {
+	ERROR_END_OF_TRANSFER = 9,
+};
+
 struct tftp_client {
 	struct list_head node;
 
@@ -467,7 +471,12 @@ static int handle_reader(struct tftp_client *client)
 	opcode = buf[0] << 8 | buf[1];
 	if (opcode == OP_ERROR) {
 		buf[len] = '\0';
-		printf("[TQFTP] Remote returned an error: %d - %s\n", buf[2] << 8 | buf[3], buf + 4);
+		int err = buf[2] << 8 | buf[3];
+		/* "End of Transfer" is not an error, used with stat(2)-like calls */
+		if (err == ERROR_END_OF_TRANSFER)
+			printf("[TQFTP] Remote returned END OF TRANSFER: %d - %s\n", err, buf + 4);
+		else
+			printf("[TQFTP] Remote returned an error: %d - %s\n", err, buf + 4);
 		return -1;
 	} else if (opcode != OP_ACK) {
 		printf("[TQFTP] Expected ACK, got %d\n", opcode);

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -67,6 +67,7 @@ struct tftp_client {
 	size_t rsize;
 	size_t wsize;
 	unsigned int timeoutms;
+	off_t seek;
 };
 
 static struct list_head readers = LIST_INIT(readers);
@@ -117,7 +118,8 @@ static int tftp_send_ack(int sock, int block)
 }
 
 static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
-			  size_t *wsize, unsigned int *timeoutms, size_t *rsize)
+			  size_t *wsize, unsigned int *timeoutms, size_t *rsize,
+			  off_t *seek)
 {
 	char buf[512];
 	char *p = buf;
@@ -171,6 +173,15 @@ static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
 		*p++ = '\0';
 	}
 
+	if (seek) {
+		strcpy(p, "seek");
+		p += 5;
+
+		n = sprintf(p, "%zd", *seek);
+		p += n;
+		*p++ = '\0';
+	}
+
 	return send(sock, buf, p - buf, 0);
 }
 
@@ -197,7 +208,7 @@ static int tftp_send_error(int sock, int code, const char *msg)
 
 static void parse_options(const char *buf, size_t len, size_t *blksize,
 			  ssize_t *tsize, size_t *wsize, unsigned int *timeoutms,
-			  size_t *rsize)
+			  size_t *rsize, off_t *seek)
 {
 	const char *opt, *value;
 	const char *p = buf;
@@ -217,6 +228,7 @@ static void parse_options(const char *buf, size_t len, size_t *blksize,
 		 * tsize: total size - request to get file size in bytes
 		 * rsize: read size - how many bytes to send, not full file
 		 * wsize: window size - how many blocks to send without ACK
+		 * seek: offset from beginning of file in bytes to start reading
 		 */
 		if (!strcmp(opt, "blksize")) {
 			*blksize = atoi(value);
@@ -228,6 +240,8 @@ static void parse_options(const char *buf, size_t len, size_t *blksize,
 			*rsize = atoi(value);
 		} else if (!strcmp(opt, "wsize")) {
 			*wsize = atoi(value);
+		} else if (!strcmp(opt, "seek")) {
+			*seek = atoi(value);
 		} else {
 			printf("[TQFTP] Ignoring unknown option '%s' with value '%s'\n", opt, value);
 		}
@@ -246,6 +260,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	unsigned int timeoutms = 1000;
 	size_t rsize = 0;
 	size_t wsize = 0;
+	off_t seek = 0;
 	bool do_oack = false;
 	int sock;
 	int ret;
@@ -270,7 +285,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	if (p < buf + len) {
 		do_oack = true;
 		parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
-				&timeoutms, &rsize);
+				&timeoutms, &rsize, &seek);
 	}
 
 	sock = qrtr_open(0);
@@ -307,6 +322,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->rsize = rsize;
 	client->wsize = wsize;
 	client->timeoutms = timeoutms;
+	client->seek = seek;
 
 	// printf("[TQFTP] new reader added\n");
 
@@ -317,7 +333,8 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 			       tsize ? (size_t*)&tsize : NULL,
 			       wsize ? &wsize : NULL,
 			       &client->timeoutms,
-			       rsize ? &rsize: NULL);
+			       rsize ? &rsize : NULL,
+			       seek ? &seek : NULL);
 	} else {
 		tftp_send_data(client, 1, 0);
 	}
@@ -334,6 +351,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	unsigned int timeoutms = 1000;
 	size_t rsize = 0;
 	size_t wsize = 0;
+	off_t seek = 0;
 	bool do_oack = false;
 	int sock;
 	int ret;
@@ -354,7 +372,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	if (p < buf + len) {
 		do_oack = true;
 		parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
-				&timeoutms, &rsize);
+				&timeoutms, &rsize, &seek);
 	}
 
 	fd = translate_open(filename, O_WRONLY | O_CREAT);
@@ -386,6 +404,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->rsize = rsize;
 	client->wsize = wsize;
 	client->timeoutms = timeoutms;
+	client->seek = seek;
 
 	// printf("[TQFTP] new writer added\n");
 
@@ -396,7 +415,8 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 			       tsize ? (size_t*)&tsize : NULL,
 			       wsize ? &wsize : NULL,
 			       &client->timeoutms,
-			       rsize ? &rsize: NULL);
+			       rsize ? &rsize : NULL,
+			       seek ? &seek : NULL);
 	} else {
 		tftp_send_data(client, 1, 0);
 	}

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -294,13 +294,13 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 		return;
 	}
 
-	printf("[TQFTP] RRQ: %s (%s)\n", filename, mode);
-
 	if (p < buf + len) {
 		do_oack = true;
 		parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
 				&timeoutms, &rsize, &seek);
 	}
+
+	printf("[TQFTP] RRQ: %s (mode=%s rsize=%ld seek=%ld)\n", filename, mode, rsize, seek);
 
 	sock = qrtr_open(0);
 	if (sock < 0) {

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -89,9 +89,8 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 	*p++ = block & 0xff;
 
 	len = pread(client->fd, p, client->blksize, offset);
-	if (len <= 0) {
-		if (len < 0)
-			printf("[TQFTP] failed to read data\n");
+	if (len < 0) {
+		printf("[TQFTP] failed to read data\n");
 		free(buf);
 		return len;
 	}


### PR DESCRIPTION
Main motivation:

The Fairphone 4 (SM7225) & Fairphone 5 (QCM6490) modems fail to get the RF up if the tftp server doesn't provide the files in the correct format. Both use a lot of rsize+offset options when requesting files, requesting some files in part, some oddly sized chunk after another (I'm sure there's some logic behind this in the modem).

There's also some stat(2)-like calls happening, which is a RRQ request with tsize set, in OACK we send back the file size of the requested file, and then the client on the modem sends us an error with "End of Transfer". After that the modem sends rsize to the size it queried and properly requests the file.

Example log:
```
[TQFTP] RRQ: /readonly/firmware/image/modem_pr/mcfg/configs/mcfg_sw/generic/NA/Dish/Commercial/US/mcfg_sw.mbn (mode=octet rsize=0 seek=0)
[TQFTP] Remote returned END OF TRANSFER: 9 - End of Transfer
[TQFTP] RRQ: /readonly/firmware/image/modem_pr/mcfg/configs/mcfg_sw/generic/NA/Dish/Commercial/US/mcfg_sw.mbn (mode=octet rsize=0 seek=0)
[TQFTP] Remote returned END OF TRANSFER: 9 - End of Transfer
[TQFTP] RRQ: /readonly/firmware/image/modem_pr/mcfg/configs/mcfg_sw/generic/NA/Dish/Commercial/US/mcfg_sw.mbn (mode=octet rsize=53760 seek=0)
[TQFTP] Sending 7684 bytes of DATA
[TQFTP] Sending 7684 bytes of DATA
[TQFTP] Sending 7684 bytes of DATA
[TQFTP] Sending 7684 bytes of DATA
[TQFTP] Sending 7684 bytes of DATA
[TQFTP] Sending 7684 bytes of DATA
[TQFTP] Sending 7684 bytes of DATA
[TQFTP] Sending 4 bytes of DATA
```

With these patches the modem on both Fairphone 4 and Fairphone 5 can connect to the network successfully. I imagine a bunch of SM8250-era (and newer) devices will also need the same support.

See commits for details.