### PR TITLE
meson: Make systemd dependency optional

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,12 +6,16 @@ project('tqftpserv',
         ])
 
 prefix = get_option('prefix')
-systemd = dependency('systemd')
-systemd_system_unit_dir = get_option('systemd-unit-prefix')
-if systemd_system_unit_dir == ''
-        systemd_system_unit_dir = systemd.get_variable(
-                pkgconfig : 'systemdsystemunitdir',
-                pkgconfig_define: ['prefix', prefix])
+
+# Not required to build the executable, only to install unit file
+systemd = dependency('systemd', required : false)
+if systemd.found()
+        systemd_system_unit_dir = get_option('systemd-unit-prefix')
+        if systemd_system_unit_dir == ''
+                systemd_system_unit_dir = systemd.get_variable(
+                        pkgconfig : 'systemdsystemunitdir',
+                        pkgconfig_define: ['prefix', prefix])
+        endif
 endif
 
 qrtr_dep = dependency('qrtr')
@@ -23,10 +27,12 @@ executable('tqftpserv',
            dependencies : qrtr_dep,
            install : true)
 
-systemd_unit_conf = configuration_data()
-systemd_unit_conf.set('prefix', prefix)
-configure_file(
-               input : 'tqftpserv.service.in',
-               output : 'tqftpserv.service',
-               configuration : systemd_unit_conf,
-               install_dir : systemd_system_unit_dir)
+if systemd.found()
+        systemd_unit_conf = configuration_data()
+        systemd_unit_conf.set('prefix', prefix)
+        configure_file(
+                input : 'tqftpserv.service.in',
+                output : 'tqftpserv.service',
+                configuration : systemd_unit_conf,
+                install_dir : systemd_system_unit_dir)
+endif


### PR DESCRIPTION
Some distros (don't point fingers) still don't use SystemD (yet), make it optional.

It is not required to build the binary, just to install systemd unit file.

Add `required : false` and wrap all manipulations with systemd unit files in `if systemd.found()`