### PR TITLE
tqftpserv.service.in: remove dependency on qrtr-ns.service

### DIFF
--- a/tqftpserv.service.in
+++ b/tqftpserv.service.in
@@ -1,7 +1,5 @@
 [Unit]
 Description=QRTR TFTP service
-Requires=qrtr-ns.service
-After=qrtr-ns.service
 
 [Service]
 ExecStart=@prefix@/bin/tqftpserv


### PR DESCRIPTION
QRTR is built in to the kernel now, the other packages (such as rmtfs) have since removed qrtr-ns as a service dependency