### PR TITLE
tqftpserv: ACK during write based on wsize

### DIFF
--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -254,7 +254,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	size_t blksize = 512;
 	unsigned int timeoutms = 1000;
 	size_t rsize = 0;
-	size_t wsize = 0;
+	size_t wsize = 1;
 	off_t seek = 0;
 	bool do_oack = false;
 	int sock;
@@ -352,7 +352,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	size_t blksize = 512;
 	unsigned int timeoutms = 1000;
 	size_t rsize = 0;
-	size_t wsize = 0;
+	size_t wsize = 1;
 	off_t seek = 0;
 	bool do_oack = false;
 	int sock;

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -46,6 +46,9 @@ struct tftp_client {
 	size_t wsize;
 	unsigned int timeoutms;
 	off_t seek;
+
+	uint8_t *rw_buf;
+	size_t rw_buf_size;
 };
 
 static struct list_head readers = LIST_INIT(readers);
@@ -315,6 +318,13 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->wsize = wsize;
 	client->timeoutms = timeoutms;
 	client->seek = seek;
+	client->rw_buf_size = blksize * wsize;
+
+	client->rw_buf = calloc(1, client->rw_buf_size);
+	if (!client->rw_buf) {
+		printf("[TQFTP] Memory allocation failure\n");
+		return;
+	}
 
 	// printf("[TQFTP] new reader added\n");
 
@@ -397,6 +407,13 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->wsize = wsize;
 	client->timeoutms = timeoutms;
 	client->seek = seek;
+	client->rw_buf_size = blksize * wsize;
+
+	client->rw_buf = calloc(1, client->rw_buf_size);
+	if (!client->rw_buf) {
+		printf("[TQFTP] Memory allocation failure\n");
+		return;
+	}
 
 	// printf("[TQFTP] new writer added\n");
 
@@ -540,6 +557,7 @@ static void client_close_and_free(struct tftp_client *client)
 	list_del(&client->node);
 	close(client->sock);
 	close(client->fd);
+	free (client->rw_buf);
 	free(client);
 }
 

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -47,6 +47,7 @@ struct tftp_client {
 	unsigned int timeoutms;
 	off_t seek;
 
+	uint8_t *blk_buf;
 	uint8_t *rw_buf;
 	size_t rw_buf_size;
 };
@@ -320,6 +321,12 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->seek = seek;
 	client->rw_buf_size = blksize * wsize;
 
+	client->blk_buf = calloc(1, blksize + 4);
+	if (!client->blk_buf) {
+		printf("[TQFTP] Memory allocation failure\n");
+		return;
+	}
+
 	client->rw_buf = calloc(1, client->rw_buf_size);
 	if (!client->rw_buf) {
 		printf("[TQFTP] Memory allocation failure\n");
@@ -408,6 +415,12 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->timeoutms = timeoutms;
 	client->seek = seek;
 	client->rw_buf_size = blksize * wsize;
+
+	client->blk_buf = calloc(1, blksize + 4);
+	if (!client->blk_buf) {
+		printf("[TQFTP] Memory allocation failure\n");
+		return;
+	}
 
 	client->rw_buf = calloc(1, client->rw_buf_size);
 	if (!client->rw_buf) {
@@ -557,6 +570,7 @@ static void client_close_and_free(struct tftp_client *client)
 	list_del(&client->node);
 	close(client->sock);
 	close(client->fd);
+	free (client->blk_buf);
 	free (client->rw_buf);
 	free(client);
 }


### PR DESCRIPTION
Client expects ACK in WRQ request based on wsize.  Fix is added to wait for wsize packets and then ACK, wsize buffers are then written to the file.
