### PR TITLE
meson.build: prepare 1.1.1 release

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@
 
 project('tqftpserv',
         'c',
-        version: '1.1',
+        version: '1.1.1',
         default_options: [
             'warning_level=1',
             'buildtype=release',


### PR DESCRIPTION
Bugfix release:
- fix zstd integration
- fix qrtr-ns service dependencies
- fix systemd unit installation
- fix buffer / ACK handling in corner cases