### PR TITLE
Sanity checks and cleanups

### DIFF
--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -772,8 +772,8 @@ static int handle_writer(struct tftp_client *client)
 	if (block % client->wsize == 0) {
 		ret = write(client->fd, client->rw_buf, client->blk_offset);
 		if (ret < 0) {
-			/* XXX: report error */
-			printf("[TQFTP] failed to write data\n");
+			printf("[TQFTP] failed to write data: %s\n", strerror(errno));
+			tftp_send_error(client->sock, TFTP_ERROR_ENOSPACE, "Disk full or write error");
 			return -1;
 		}
 

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -18,6 +18,20 @@
 
 #define MAX(x, y) ((x) > (y) ? (x) : (y))
 
+/* RFC 2348: TFTP Blocksize Option - valid range 8 to 65464 bytes */
+#define MIN_BLKSIZE 8
+#define MAX_BLKSIZE 65464
+
+/* RFC 7440: TFTP Windowsize Option - valid range 1 to 65535 */
+#define MIN_WSIZE 1
+#define MAX_WSIZE 65535
+
+/* Reasonable limits for custom options */
+#define MAX_RSIZE (100 * 1024 * 1024)  /* 100 MB */
+#define MIN_TIMEOUTMS 1
+#define MAX_TIMEOUTMS 255000  /* 255 seconds */
+#define MIN_SEEK 0
+
 enum {
 	OP_RRQ = 1,
 	OP_WRQ,
@@ -86,6 +100,32 @@ static int tftp_send_error(int sock, enum tftp_error code, const char *msg)
 	rc = send(sock, buf, len, 0);
 	free(buf);
 	return rc;
+}
+
+/**
+ * tftp_send_error_to() - send TFTP ERROR packet to a remote address
+ * @sq: remote address to send error to
+ * @code: TFTP error code
+ * @msg: error message string
+ *
+ * Creates a temporary socket, connects to the remote address, sends an
+ * ERROR packet, and closes the socket. This is used when we need to send
+ * an error before establishing a client session.
+ */
+static void tftp_send_error_to(struct sockaddr_qrtr *sq, enum tftp_error code, const char *msg)
+{
+	int sock;
+	int ret;
+
+	sock = qrtr_open(0);
+	if (sock < 0)
+		return;
+
+	ret = connect(sock, (struct sockaddr *)sq, sizeof(*sq));
+	if (ret >= 0)
+		tftp_send_error(sock, code, msg);
+
+	close(sock);
 }
 
 static ssize_t tftp_send_data(struct tftp_client *client,
@@ -207,21 +247,42 @@ static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
 	return send(sock, buf, p - buf, 0);
 }
 
-static void parse_options(const char *buf, size_t len, size_t *blksize,
-			  ssize_t *tsize, size_t *wsize, unsigned int *timeoutms,
-			  size_t *rsize, off_t *seek)
+static int parse_options(const char *buf, size_t len, size_t *blksize,
+			 ssize_t *tsize, size_t *wsize, unsigned int *timeoutms,
+			 size_t *rsize, off_t *seek)
 {
 	const char *opt, *value;
+	long long parsed_val;
+	const char *end = buf + len;
 	const char *p = buf;
+	size_t value_len;
+	size_t opt_len;
+	char *endptr;
 
-	while (p < buf + len) {
-		/* XXX: ensure we're not running off the end */
+	while (p < end) {
+		/* Ensure option string is null-terminated within buffer */
 		opt = p;
-		p += strlen(p) + 1;
+		opt_len = strnlen(opt, end - p);
+		if (opt_len == (size_t)(end - p)) {
+			printf("[TQFTP] Malformed options: option not null-terminated\n");
+			return -1;
+		}
+		p += opt_len + 1;
 
-		/* XXX: ensure we're not running off the end */
+		/* Ensure we have space for value string */
+		if (p >= end) {
+			printf("[TQFTP] Malformed options: missing value\n");
+			return -1;
+		}
+
+		/* Ensure value string is null-terminated within buffer */
 		value = p;
-		p += strlen(p) + 1;
+		value_len = strnlen(value, end - p);
+		if (value_len == (size_t)(end - p)) {
+			printf("[TQFTP] Malformed options: value not null-terminated\n");
+			return -1;
+		}
+		p += value_len + 1;
 
 		/*
 		 * blksize: block size - how many bytes to send at once
@@ -232,21 +293,64 @@ static void parse_options(const char *buf, size_t len, size_t *blksize,
 		 * seek: offset from beginning of file in bytes to start reading
 		 */
 		if (!strcmp(opt, "blksize")) {
-			*blksize = atoi(value);
+			errno = 0;
+			parsed_val = strtoll(value, &endptr, 10);
+			if (errno != 0 || *endptr != '\0' || parsed_val < MIN_BLKSIZE || parsed_val > MAX_BLKSIZE) {
+				printf("[TQFTP] Invalid blksize value '%s' (must be %d-%d)\n",
+				       value, MIN_BLKSIZE, MAX_BLKSIZE);
+				return -1;
+			}
+			*blksize = (size_t)parsed_val;
 		} else if (!strcmp(opt, "timeoutms")) {
-			*timeoutms = atoi(value);
+			errno = 0;
+			parsed_val = strtoll(value, &endptr, 10);
+			if (errno != 0 || *endptr != '\0' || parsed_val < MIN_TIMEOUTMS || parsed_val > MAX_TIMEOUTMS) {
+				printf("[TQFTP] Invalid timeoutms value '%s' (must be %d-%d)\n",
+				       value, MIN_TIMEOUTMS, MAX_TIMEOUTMS);
+				return -1;
+			}
+			*timeoutms = (unsigned int)parsed_val;
 		} else if (!strcmp(opt, "tsize")) {
-			*tsize = atoi(value);
+			errno = 0;
+			parsed_val = strtoll(value, &endptr, 10);
+			if (errno != 0 || *endptr != '\0' || parsed_val < 0) {
+				printf("[TQFTP] Invalid tsize value '%s'\n", value);
+				return -1;
+			}
+			*tsize = (ssize_t)parsed_val;
 		} else if (!strcmp(opt, "rsize")) {
-			*rsize = atoi(value);
+			errno = 0;
+			parsed_val = strtoll(value, &endptr, 10);
+			if (errno != 0 || *endptr != '\0' || parsed_val < 1 || parsed_val > MAX_RSIZE) {
+				printf("[TQFTP] Invalid rsize value '%s' (must be 1-%d)\n",
+				       value, MAX_RSIZE);
+				return -1;
+			}
+			*rsize = (size_t)parsed_val;
 		} else if (!strcmp(opt, "wsize")) {
-			*wsize = atoi(value);
+			errno = 0;
+			parsed_val = strtoll(value, &endptr, 10);
+			if (errno != 0 || *endptr != '\0' || parsed_val < MIN_WSIZE || parsed_val > MAX_WSIZE) {
+				printf("[TQFTP] Invalid wsize value '%s' (must be %d-%d)\n",
+				       value, MIN_WSIZE, MAX_WSIZE);
+				return -1;
+			}
+			*wsize = (size_t)parsed_val;
 		} else if (!strcmp(opt, "seek")) {
-			*seek = atoi(value);
+			errno = 0;
+			parsed_val = strtoll(value, &endptr, 10);
+			if (errno != 0 || *endptr != '\0' || parsed_val < MIN_SEEK) {
+				printf("[TQFTP] Invalid seek value '%s' (must be >= %d)\n",
+				       value, MIN_SEEK);
+				return -1;
+			}
+			*seek = (off_t)parsed_val;
 		} else {
 			printf("[TQFTP] Ignoring unknown option '%s' with value '%s'\n", opt, value);
 		}
 	}
+
+	return 0;
 }
 
 static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
@@ -283,8 +387,13 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	if (p < buf + len) {
 		do_oack = true;
-		parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
-				&timeoutms, &rsize, &seek);
+		ret = parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
+				    &timeoutms, &rsize, &seek);
+		if (ret < 0) {
+			printf("[TQFTP] Invalid options in RRQ, rejecting\n");
+			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG, "Option negotiation failed");
+			return;
+		}
 	}
 
 	printf("[TQFTP] RRQ: %s (mode=%s rsize=%ld seek=%ld)\n", filename, mode, rsize, seek);
@@ -385,8 +494,13 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	if (p < buf + len) {
 		do_oack = true;
-		parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
-				&timeoutms, &rsize, &seek);
+		ret = parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
+				    &timeoutms, &rsize, &seek);
+		if (ret < 0) {
+			printf("[TQFTP] Invalid options in WRQ, rejecting\n");
+			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG, "Option negotiation failed");
+			return;
+		}
 	}
 
 	fd = translate_open(filename, O_WRONLY | O_CREAT);

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -733,6 +733,7 @@ static int handle_reader(struct tftp_client *client)
 		return -1;
 	} else if (opcode != OP_ACK) {
 		printf("[TQFTP] Expected ACK, got %d\n", opcode);
+		tftp_send_error(client->sock, TFTP_ERROR_EBADOP, "Expected ACK opcode");
 		return -1;
 	}
 

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -360,6 +360,8 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	const char *mode;
 	struct stat sb;
 	const char *p;
+	const char *end = buf + len;
+	size_t filename_len, mode_len;
 	ssize_t tsize = -1;
 	size_t blksize = 512;
 	unsigned int timeoutms = 1000;
@@ -373,11 +375,27 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	p = buf + 2;
 
+	/* Parse filename - ensure it's NUL-terminated within buffer */
 	filename = p;
-	p += strlen(p) + 1;
+	filename_len = strnlen(filename, end - p);
+	if (filename_len == (size_t)(end - p)) {
+		printf("[TQFTP] RRQ: filename not NUL-terminated\n");
+		return;
+	}
+	p += filename_len + 1;
 
+	/* Parse mode - ensure it's NUL-terminated within buffer */
+	if (p >= end) {
+		printf("[TQFTP] RRQ: truncated packet, missing mode\n");
+		return;
+	}
 	mode = p;
-	p += strlen(p) + 1;
+	mode_len = strnlen(mode, end - p);
+	if (mode_len == (size_t)(end - p)) {
+		printf("[TQFTP] RRQ: mode not NUL-terminated\n");
+		return;
+	}
+	p += mode_len + 1;
 
 	if (strcasecmp(mode, "octet")) {
 		/* XXX: error */
@@ -469,6 +487,8 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	const char *filename;
 	const char *mode;
 	const char *p;
+	const char *end = buf + len;
+	size_t filename_len, mode_len;
 	ssize_t tsize = -1;
 	size_t blksize = 512;
 	unsigned int timeoutms = 1000;
@@ -480,9 +500,29 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	int ret;
 	int fd;
 
-	filename = buf + 2;
-	mode = buf + 2 + strlen(filename) + 1;
-	p = mode + strlen(mode) + 1;
+	p = buf + 2;
+
+	/* Parse filename - ensure it's NUL-terminated within buffer */
+	filename = p;
+	filename_len = strnlen(filename, end - p);
+	if (filename_len == (size_t)(end - p)) {
+		printf("[TQFTP] WRQ: filename not NUL-terminated\n");
+		return;
+	}
+	p += filename_len + 1;
+
+	/* Parse mode - ensure it's NUL-terminated within buffer */
+	if (p >= end) {
+		printf("[TQFTP] WRQ: truncated packet, missing mode\n");
+		return;
+	}
+	mode = p;
+	mode_len = strnlen(mode, end - p);
+	if (mode_len == (size_t)(end - p)) {
+		printf("[TQFTP] WRQ: mode not NUL-terminated\n");
+		return;
+	}
+	p += mode_len + 1;
 
 	if (strcasecmp(mode, "octet")) {
 		/* XXX: error */

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -146,7 +146,6 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 	if (len < 0) {
 		printf("[TQFTP] failed to read data: %s\n", strerror(errno));
 		tftp_send_error(client->sock, TFTP_ERROR_UNDEF, "Read error");
-		free(buf);
 		return len;
 	}
 
@@ -158,7 +157,6 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 		send_len = 4 + response_size;
 		if (send_len > p - buf) {
 			printf("[TQFTP] requested data of %ld bytes but only read %ld bytes from file, rejecting\n", response_size, len);
-			free(buf);
 			return -EINVAL;
 		}
 	} else {

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -200,6 +200,7 @@ static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
 			  off_t *seek)
 {
 	char buf[512];
+	char *end = buf + sizeof(buf);
 	char *p = buf;
 	int n;
 
@@ -207,55 +208,79 @@ static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
 	*p++ = OP_OACK;
 
 	if (blocksize) {
-		strcpy(p, "blksize");
+		if (p + 8 >= end)
+			return -1;
+		memcpy(p, "blksize", 8);
 		p += 8;
 
-		n = sprintf(p, "%zd", *blocksize);
+		n = snprintf(p, end - p, "%zd", *blocksize);
+		if (n < 0 || n >= end - p)
+			return -1;
 		p += n;
 		*p++ = '\0';
 	}
 
 	if (timeoutms) {
-		strcpy(p, "timeoutms");
+		if (p + 10 >= end)
+			return -1;
+		memcpy(p, "timeoutms", 10);
 		p += 10;
 
-		n = sprintf(p, "%d", *timeoutms);
+		n = snprintf(p, end - p, "%d", *timeoutms);
+		if (n < 0 || n >= end - p)
+			return -1;
 		p += n;
 		*p++ = '\0';
 	}
 
 	if (tsize && *tsize != -1) {
-		strcpy(p, "tsize");
+		if (p + 6 >= end)
+			return -1;
+		memcpy(p, "tsize", 6);
 		p += 6;
 
-		n = sprintf(p, "%zd", *tsize);
+		n = snprintf(p, end - p, "%zd", *tsize);
+		if (n < 0 || n >= end - p)
+			return -1;
 		p += n;
 		*p++ = '\0';
 	}
 
 	if (wsize) {
-		strcpy(p, "wsize");
+		if (p + 6 >= end)
+			return -1;
+		memcpy(p, "wsize", 6);
 		p += 6;
 
-		n = sprintf(p, "%zd", *wsize);
+		n = snprintf(p, end - p, "%zd", *wsize);
+		if (n < 0 || n >= end - p)
+			return -1;
 		p += n;
 		*p++ = '\0';
 	}
 
 	if (rsize) {
-		strcpy(p, "rsize");
+		if (p + 6 >= end)
+			return -1;
+		memcpy(p, "rsize", 6);
 		p += 6;
 
-		n = sprintf(p, "%zd", *rsize);
+		n = snprintf(p, end - p, "%zd", *rsize);
+		if (n < 0 || n >= end - p)
+			return -1;
 		p += n;
 		*p++ = '\0';
 	}
 
 	if (seek) {
-		strcpy(p, "seek");
+		if (p + 5 >= end)
+			return -1;
+		memcpy(p, "seek", 5);
 		p += 5;
 
-		n = sprintf(p, "%zd", *seek);
+		n = snprintf(p, end - p, "%zd", *seek);
+		if (n < 0 || n >= end - p)
+			return -1;
 		p += n;
 		*p++ = '\0';
 	}

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -545,8 +545,8 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	fd = translate_open(filename, O_WRONLY | O_CREAT);
 	if (fd < 0) {
-		/* XXX: error */
 		printf("[TQFTP] unable to open %s (%d), reject\n", filename, errno);
+		tftp_send_error_to(sq, TFTP_ERROR_EACCESS, "Access violation");
 		return;
 	}
 

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -97,6 +97,26 @@ static void log_debug(const char *fmt, ...)
 	fflush(stderr);
 }
 
+static void log_err(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fflush(stderr);
+}
+
+static void log_info(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vfprintf(stdout, fmt, ap);
+	va_end(ap);
+	fflush(stderr);
+}
+
 static int sanitize_path(const char *path)
 {
 	const char *p;
@@ -104,10 +124,8 @@ static int sanitize_path(const char *path)
 	/* Check for "../" or "/../" */
 	for (p = path; *p; p++) {
 		if (p[0] == '.' && p[1] == '.' && p[2] == '/') {
-			if (p == path || p[-1] == '/') {
-				printf("[TQFTP] Directory traversal rejected: %s\n", path);
+			if (p == path || p[-1] == '/')
 				return -1;
-			}
 		}
 	}
 
@@ -177,7 +195,7 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 
 	len = pread(client->fd, p, client->blksize, offset);
 	if (len < 0) {
-		printf("[TQFTP] failed to read data: %s\n", strerror(errno));
+		log_err("failed to read data: %s\n", strerror(errno));
 		tftp_send_error(client->sock, TFTP_ERROR_UNDEF, "Read error");
 		return len;
 	}
@@ -189,14 +207,15 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 		/* Header (4 bytes) + data size */
 		send_len = 4 + response_size;
 		if (send_len > p - buf) {
-			printf("[TQFTP] requested data of %ld bytes but only read %ld bytes from file, rejecting\n", response_size, len);
+			log_err("requested data of %ld bytes but only read %ld bytes from file, rejecting\n",
+				response_size, len);
 			return -EINVAL;
 		}
 	} else {
 		send_len = p - buf;
 	}
 
-	log_debug("[TQFTP] Sending %zd bytes of DATA\n", send_len);
+	log_debug("Sending %zd bytes of DATA to %d:%d\n", send_len, client->sq.sq_node, client->sq.sq_port);
 	return send(client->sock, buf, send_len, 0);
 }
 
@@ -321,14 +340,14 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 		opt = p;
 		opt_len = strnlen(opt, end - p);
 		if (opt_len == (size_t)(end - p)) {
-			printf("[TQFTP] Malformed options: option not null-terminated\n");
+			log_err("Malformed options: option not null-terminated\n");
 			return -1;
 		}
 		p += opt_len + 1;
 
 		/* Ensure we have space for value string */
 		if (p >= end) {
-			printf("[TQFTP] Malformed options: missing value\n");
+			log_err("Malformed options: missing value\n");
 			return -1;
 		}
 
@@ -336,7 +355,7 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 		value = p;
 		value_len = strnlen(value, end - p);
 		if (value_len == (size_t)(end - p)) {
-			printf("[TQFTP] Malformed options: value not null-terminated\n");
+			log_err("Malformed options: value not null-terminated\n");
 			return -1;
 		}
 		p += value_len + 1;
@@ -353,8 +372,8 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 			errno = 0;
 			parsed_val = strtoll(value, &endptr, 10);
 			if (errno != 0 || *endptr != '\0' || parsed_val < MIN_BLKSIZE || parsed_val > MAX_BLKSIZE) {
-				printf("[TQFTP] Invalid blksize value '%s' (must be %d-%d)\n",
-				       value, MIN_BLKSIZE, MAX_BLKSIZE);
+				log_err("Invalid blksize value '%s' (must be %d-%d)\n",
+					value, MIN_BLKSIZE, MAX_BLKSIZE);
 				return -1;
 			}
 			*blksize = (size_t)parsed_val;
@@ -362,8 +381,8 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 			errno = 0;
 			parsed_val = strtoll(value, &endptr, 10);
 			if (errno != 0 || *endptr != '\0' || parsed_val < MIN_TIMEOUTMS || parsed_val > MAX_TIMEOUTMS) {
-				printf("[TQFTP] Invalid timeoutms value '%s' (must be %d-%d)\n",
-				       value, MIN_TIMEOUTMS, MAX_TIMEOUTMS);
+				log_err("Invalid timeoutms value '%s' (must be %d-%d)\n",
+					value, MIN_TIMEOUTMS, MAX_TIMEOUTMS);
 				return -1;
 			}
 			*timeoutms = (unsigned int)parsed_val;
@@ -371,7 +390,7 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 			errno = 0;
 			parsed_val = strtoll(value, &endptr, 10);
 			if (errno != 0 || *endptr != '\0' || parsed_val < 0) {
-				printf("[TQFTP] Invalid tsize value '%s'\n", value);
+				log_err("Invalid tsize value '%s'\n", value);
 				return -1;
 			}
 			*tsize = (ssize_t)parsed_val;
@@ -379,8 +398,8 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 			errno = 0;
 			parsed_val = strtoll(value, &endptr, 10);
 			if (errno != 0 || *endptr != '\0' || parsed_val < 1 || parsed_val > MAX_RSIZE) {
-				printf("[TQFTP] Invalid rsize value '%s' (must be 1-%d)\n",
-				       value, MAX_RSIZE);
+				log_err("Invalid rsize value '%s' (must be 1-%d)\n",
+					value, MAX_RSIZE);
 				return -1;
 			}
 			*rsize = (size_t)parsed_val;
@@ -388,8 +407,8 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 			errno = 0;
 			parsed_val = strtoll(value, &endptr, 10);
 			if (errno != 0 || *endptr != '\0' || parsed_val < MIN_WSIZE || parsed_val > MAX_WSIZE) {
-				printf("[TQFTP] Invalid wsize value '%s' (must be %d-%d)\n",
-				       value, MIN_WSIZE, MAX_WSIZE);
+				log_err("Invalid wsize value '%s' (must be %d-%d)\n",
+					value, MIN_WSIZE, MAX_WSIZE);
 				return -1;
 			}
 			*wsize = (size_t)parsed_val;
@@ -397,13 +416,13 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 			errno = 0;
 			parsed_val = strtoll(value, &endptr, 10);
 			if (errno != 0 || *endptr != '\0' || parsed_val < MIN_SEEK) {
-				printf("[TQFTP] Invalid seek value '%s' (must be >= %d)\n",
-				       value, MIN_SEEK);
+				log_err("Invalid seek value '%s' (must be >= %d)\n",
+					value, MIN_SEEK);
 				return -1;
 			}
 			*seek = (off_t)parsed_val;
 		} else {
-			printf("[TQFTP] Ignoring unknown option '%s' with value '%s'\n", opt, value);
+			log_err("Ignoring unknown option '%s' with value '%s'\n", opt, value);
 		}
 	}
 
@@ -435,32 +454,34 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	filename = p;
 	filename_len = strnlen(filename, end - p);
 	if (filename_len == (size_t)(end - p)) {
-		printf("[TQFTP] RRQ: filename not NUL-terminated\n");
+		log_err("RRQ: filename not NUL-terminated\n");
 		return;
 	}
 	p += filename_len + 1;
 
 	/* Parse mode - ensure it's NUL-terminated within buffer */
 	if (p >= end) {
-		printf("[TQFTP] RRQ: truncated packet, missing mode\n");
+		log_err("RRQ: truncated packet, missing mode\n");
 		return;
 	}
 	mode = p;
 	mode_len = strnlen(mode, end - p);
 	if (mode_len == (size_t)(end - p)) {
-		printf("[TQFTP] RRQ: mode not NUL-terminated\n");
+		log_err("RRQ: mode not NUL-terminated\n");
 		return;
 	}
 	p += mode_len + 1;
 
 	if (strcasecmp(mode, "octet")) {
-		printf("[TQFTP] RRQ: unsupported mode '%s', rejecting\n", mode);
+		log_err("RRQ: unsupported mode '%s', rejecting\n", mode);
 		tftp_send_error_to(sq, TFTP_ERROR_EBADOP, "Only octet mode supported");
 		return;
 	}
 
 	/* Validate filename for path traversal attacks */
 	if (sanitize_path(filename) < 0) {
+		log_err("read with invalid filename requested from %d:%d: %s\n",
+			sq->sq_node, sq->sq_port, filename);
 		tftp_send_error_to(sq, TFTP_ERROR_EACCESS, "Access violation");
 		return;
 	}
@@ -470,30 +491,31 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 		ret = parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
 				    &timeoutms, &rsize, &seek);
 		if (ret < 0) {
-			printf("[TQFTP] Invalid options in RRQ, rejecting\n");
+			log_err("Invalid options in RRQ, rejecting\n");
 			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG, "Option negotiation failed");
 			return;
 		}
 	}
 
-	printf("[TQFTP] RRQ: %s (mode=%s rsize=%ld seek=%ld)\n", filename, mode, rsize, seek);
+	log_debug("read request for %s (mode: %s, rsize: %d, seek: %d) from %d:%d\n",
+		  filename, mode, rsize, seek, sq->sq_node, sq->sq_port);
 
 	sock = qrtr_open(0);
 	if (sock < 0) {
-		printf("[TQFTP] unable to create new qrtr socket, reject\n");
+		log_err("unable to create new qrtr socket, reject\n");
 		return;
 	}
 
 	ret = connect(sock, (struct sockaddr *)sq, sizeof(*sq));
 	if (ret < 0) {
-		printf("[TQFTP] unable to connect new qrtr socket to remote\n");
+		log_err("unable to connect new qrtr socket to remote\n");
 		goto out_close_sock;
 		return;
 	}
 
 	fd = translate_open(filename, O_RDONLY);
 	if (fd < 0) {
-		printf("[TQFTP] unable to open %s (%d), reject\n", filename, errno);
+		log_err("unable to open %s (%d), reject\n", filename, errno);
 		tftp_send_error(sock, TFTP_ERROR_ENOENT, "file not found");
 		goto out_close_sock;
 		return;
@@ -502,8 +524,8 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	if (tsize != -1) {
 		tsize = lseek(fd, 0, SEEK_END);
 		if (tsize < 0) {
-			printf("[TQFTP] unable to determine file size for %s: %s\n",
-			       filename, strerror(errno));
+			log_err("unable to determine file size for %s: %s\n",
+				filename, strerror(errno));
 			tftp_send_error(sock, TFTP_ERROR_UNDEF, "Cannot determine file size");
 			goto out_close_sock;
 			return;
@@ -525,7 +547,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	client->blk_buf = calloc(1, blksize + 4);
 	if (!client->blk_buf) {
-		printf("[TQFTP] Memory allocation failure\n");
+		log_err("Memory allocation failure\n");
 		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
 		goto out_free_client;
 		return;
@@ -533,13 +555,13 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	client->rw_buf = calloc(1, client->rw_buf_size);
 	if (!client->rw_buf) {
-		printf("[TQFTP] Memory allocation failure\n");
+		log_err("Memory allocation failure\n");
 		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
 		goto out_free_blk_buf;
 		return;
 	}
 
-	log_debug("[TQFTP] new reader added\n");
+	log_info("%s opened for reading from %d:%d\n", filename, sq->sq_node, sq->sq_port);
 
 	list_add(&readers, &client->node);
 
@@ -590,34 +612,36 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	filename = p;
 	filename_len = strnlen(filename, end - p);
 	if (filename_len == (size_t)(end - p)) {
-		printf("[TQFTP] WRQ: filename not NUL-terminated\n");
+		log_err("WRQ: filename not NUL-terminated\n");
 		return;
 	}
 	p += filename_len + 1;
 
 	/* Parse mode - ensure it's NUL-terminated within buffer */
 	if (p >= end) {
-		printf("[TQFTP] WRQ: truncated packet, missing mode\n");
+		log_err("WRQ: truncated packet, missing mode\n");
 		return;
 	}
 	mode = p;
 	mode_len = strnlen(mode, end - p);
 	if (mode_len == (size_t)(end - p)) {
-		printf("[TQFTP] WRQ: mode not NUL-terminated\n");
+		log_err("WRQ: mode not NUL-terminated\n");
 		return;
 	}
 	p += mode_len + 1;
 
 	if (strcasecmp(mode, "octet")) {
-		printf("[TQFTP] WRQ: unsupported mode '%s', rejecting\n", mode);
+		log_err("WRQ: unsupported mode '%s', rejecting\n", mode);
 		tftp_send_error_to(sq, TFTP_ERROR_EBADOP, "Only octet mode supported");
 		return;
 	}
 
-	printf("[TQFTP] WRQ: %s (%s)\n", filename, mode);
+	log_debug("write request for %s (%s) from %d:%d\n", filename, mode, sq->sq_node, sq->sq_port);
 
 	/* Validate filename for path traversal attacks */
 	if (sanitize_path(filename) < 0) {
+		log_err("write with invalid filename requested from %d:%d: %s\n",
+			sq->sq_node, sq->sq_port, filename);
 		tftp_send_error_to(sq, TFTP_ERROR_EACCESS, "Access violation");
 		return;
 	}
@@ -627,7 +651,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 		ret = parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
 				    &timeoutms, &rsize, &seek);
 		if (ret < 0) {
-			printf("[TQFTP] Invalid options in WRQ, rejecting\n");
+			log_err("Invalid options in WRQ, rejecting\n");
 			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG, "Option negotiation failed");
 			return;
 		}
@@ -635,21 +659,21 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	fd = translate_open(filename, O_WRONLY | O_CREAT);
 	if (fd < 0) {
-		printf("[TQFTP] unable to open %s (%d), reject\n", filename, errno);
+		log_debug("unable to open %s (%d), reject\n", filename, errno);
 		tftp_send_error_to(sq, TFTP_ERROR_EACCESS, "Access violation");
 		return;
 	}
 
 	sock = qrtr_open(0);
 	if (sock < 0) {
-		printf("[TQFTP] unable to create new qrtr socket, reject\n");
+		log_err("unable to create new qrtr socket, reject\n");
 		goto out_close_fd;
 		return;
 	}
 
 	ret = connect(sock, (struct sockaddr *)sq, sizeof(*sq));
 	if (ret < 0) {
-		printf("[TQFTP] unable to connect new qrtr socket to remote\n");
+		log_err("unable to connect new qrtr socket to remote\n");
 		goto out_close_sock;
 		return;
 	}
@@ -668,7 +692,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	client->blk_buf = calloc(1, blksize + 4);
 	if (!client->blk_buf) {
-		printf("[TQFTP] Memory allocation failure\n");
+		log_err("Memory allocation failure\n");
 		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
 		goto out_free_client;
 		return;
@@ -676,13 +700,13 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	client->rw_buf = calloc(1, client->rw_buf_size);
 	if (!client->rw_buf) {
-		printf("[TQFTP] Memory allocation failure\n");
+		log_err("Memory allocation failure\n");
 		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
 		goto out_free_blk_buf;
 		return;
 	}
 
-	log_debug("[TQFTP] new writer added at %d:%d\n", sq->sq_node, sq->sq_port);
+	log_info("%s opened for writing from %d:%d\n", filename, sq->sq_node, sq->sq_port);
 
 	list_add(&writers, &client->node);
 
@@ -726,14 +750,14 @@ static int handle_reader(struct tftp_client *client)
 	if (len < 0) {
 		ret = -errno;
 		if (ret != -ENETRESET)
-			fprintf(stderr, "[TQFTP] recvfrom failed: %d\n", ret);
+			log_err("recvfrom failed when handling reader: %d\n", ret);
 		return -1;
 	}
 
 	/* Drop unsolicited messages */
 	if (sq.sq_node != client->sq.sq_node ||
 	    sq.sq_port != client->sq.sq_port) {
-		printf("[TQFTP] Discarding spoofed message\n");
+		log_debug("Discarding spoofed message\n");
 		return -1;
 	}
 
@@ -743,18 +767,18 @@ static int handle_reader(struct tftp_client *client)
 		int err = buf[2] << 8 | buf[3];
 		/* "End of Transfer" is not an error, used with stat(2)-like calls */
 		if (err == ERROR_END_OF_TRANSFER)
-			printf("[TQFTP] Remote returned END OF TRANSFER: %d - %s\n", err, buf + 4);
+			log_info("Reader received end of transfer from %d:%d\n", sq.sq_node, sq.sq_port);
 		else
-			printf("[TQFTP] Remote returned an error: %d - %s\n", err, buf + 4);
+			log_err("Remote returned an error: %d - %s\n", err, buf + 4);
 		return -1;
 	} else if (opcode != OP_ACK) {
-		printf("[TQFTP] Expected ACK, got %d\n", opcode);
+		log_err("Expected ACK, got %d\n", opcode);
 		tftp_send_error(client->sock, TFTP_ERROR_EBADOP, "Expected ACK opcode");
 		return -1;
 	}
 
 	last = buf[2] << 8 | buf[3];
-	log_debug("[TQFTP] Got ack for %d from %d:%d\n", last, sq.sq_node, sq.sq_port);
+	log_debug("Got ack for %d from %d:%d\n", last, sq.sq_node, sq.sq_port);
 
 	/* We've sent enough data for rsize already */
 	if (last * client->blksize > client->rsize)
@@ -770,10 +794,10 @@ static int handle_reader(struct tftp_client *client)
 		n = tftp_send_data(client, block + 1,
 				   offset, response_size);
 		if (n < 0) {
-			printf("[TQFTP] Sent block %d failed: %zd\n", block + 1, n);
+			log_err("Sent block %d failed: %zd\n", block + 1, n);
 			break;
 		}
-		log_debug("[TQFTP] Sent block %d of %zd to %d:%d\n", block + 1, n, sq.sq_node, sq.sq_port);
+		log_debug("Sent block %d of %zd to %d:%d\n", block + 1, n, sq.sq_node, sq.sq_port);
 		if (n == 0)
 			break;
 		/* We've sent enough data for rsize already */
@@ -800,7 +824,7 @@ static int handle_writer(struct tftp_client *client)
 	if (len < 0) {
 		ret = -errno;
 		if (ret != -ENETRESET)
-			fprintf(stderr, "[TQFTP] recvfrom failed: %d\n", ret);
+			log_err("recvfrom failed when handling writer: %d\n", ret);
 		return -1;
 	}
 
@@ -812,7 +836,7 @@ static int handle_writer(struct tftp_client *client)
 	opcode = buf[0] << 8 | buf[1];
 	block = buf[2] << 8 | buf[3];
 	if (opcode != OP_DATA) {
-		printf("[TQFTP] Expected DATA opcode, got %d\n", opcode);
+		log_err("Expected DATA opcode, got %d\n", opcode);
 		tftp_send_error(client->sock, TFTP_ERROR_EBADOP, "Expected DATA opcode");
 		return -1;
 	}
@@ -824,8 +848,7 @@ static int handle_writer(struct tftp_client *client)
 	if (block != client->blk_expected) {
 		uint16_t blk_expected = client->blk_expected;
 
-		printf("[TQFTP] Block number out of sequence: %d (expected %d)\n",
-			 block, blk_expected);
+		log_err("Block number out of sequence: %d (expected %d)\n", block, blk_expected);
 		tftp_send_error(client->sock, TFTP_ERROR_EBADOP, "Block number out of sequence");
 
 		/* Set blk_expected to beginning of current window */
@@ -850,7 +873,7 @@ static int handle_writer(struct tftp_client *client)
 	if (block % client->wsize == 0) {
 		ret = write(client->fd, client->rw_buf, client->blk_offset);
 		if (ret < 0) {
-			printf("[TQFTP] failed to write data: %s\n", strerror(errno));
+			log_err("failed to write data: %s\n", strerror(errno));
 			tftp_send_error(client->sock, TFTP_ERROR_ENOSPACE, "Disk full or write error");
 			return -1;
 		}
@@ -948,7 +971,7 @@ int main(int argc, char **argv)
 			if (errno == EINTR) {
 				continue;
 			} else {
-				fprintf(stderr, "select failed\n");
+				log_err("select failed\n");
 				break;
 			}
 		}
@@ -975,7 +998,7 @@ int main(int argc, char **argv)
 			if (len < 0) {
 				ret = -errno;
 				if (ret != -ENETRESET)
-					fprintf(stderr, "[TQFTP] recvfrom failed: %d\n", ret);
+					fprintf(stderr, "recvfrom failed on control socket: %d\n", ret);
 				return ret;
 			}
 
@@ -983,20 +1006,20 @@ int main(int argc, char **argv)
 			if (sq.sq_port == QRTR_PORT_CTRL) {
 				ret = qrtr_decode(&pkt, buf, len, &sq);
 				if (ret < 0) {
-					fprintf(stderr, "[TQFTP] unable to decode qrtr packet\n");
+					fprintf(stderr, "unable to decode qrtr packet\n");
 					return ret;
 				}
 
 				switch (pkt.type) {
 				case QRTR_TYPE_BYE:
-					log_debug("[TQFTP] got bye for %d\n", pkt.node);
+					log_debug("got bye for %d\n", pkt.node);
 					list_for_each_entry_safe(client, next, &writers, node) {
 						if (client->sq.sq_node == sq.sq_node)
 							client_close_and_free(client);
 					}
 					break;
 				case QRTR_TYPE_DEL_CLIENT:
-					log_debug("[TQFTP] got del_client for %d:%d\n", pkt.node, pkt.port);
+					log_debug("got del_client for %d:%d\n", pkt.node, pkt.port);
 					list_for_each_entry_safe(client, next, &writers, node) {
 						if (!memcmp(&client->sq, &sq, sizeof(sq)))
 							client_close_and_free(client);
@@ -1017,10 +1040,12 @@ int main(int argc, char **argv)
 					break;
 				case OP_ERROR:
 					buf[len] = '\0';
-					printf("[TQFTP] received error: %d - %s\n", buf[2] << 8 | buf[3], buf + 4);
+					log_err("received error %d from %d:%d: %s\n",
+						buf[2] << 8 | buf[3], sq.sq_node, sq.sq_port, buf + 4);
 					break;
 				default:
-					printf("[TQFTP] unhandled op %d\n", opcode);
+					log_err("unhandled op %d from %d:%d\n",
+						opcode, sq.sq_node, sq.sq_port);
 					break;
 				}
 			}

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -357,7 +357,6 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	struct tftp_client *client;
 	const char *filename;
 	const char *mode;
-	struct stat sb;
 	const char *p;
 	const char *end = buf + len;
 	size_t filename_len, mode_len;
@@ -437,8 +436,16 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	}
 
 	if (tsize != -1) {
-		fstat(fd, &sb);
-		tsize = sb.st_size;
+		tsize = lseek(fd, 0, SEEK_END);
+		if (tsize < 0) {
+			printf("[TQFTP] unable to determine file size for %s: %s\n",
+			       filename, strerror(errno));
+			tftp_send_error(sock, TFTP_ERROR_UNDEF, "Cannot determine file size");
+			goto out_close_sock;
+			return;
+		}
+		/* Reset file position to beginning */
+		lseek(fd, 0, SEEK_SET);
 	}
 
 	client = calloc(1, sizeof(*client));

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -398,8 +398,8 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	p += mode_len + 1;
 
 	if (strcasecmp(mode, "octet")) {
-		/* XXX: error */
-		printf("[TQFTP] not octet, reject\n");
+		printf("[TQFTP] RRQ: unsupported mode '%s', rejecting\n", mode);
+		tftp_send_error_to(sq, TFTP_ERROR_EBADOP, "Only octet mode supported");
 		return;
 	}
 
@@ -525,8 +525,8 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	p += mode_len + 1;
 
 	if (strcasecmp(mode, "octet")) {
-		/* XXX: error */
-		printf("[TQFTP] not octet, reject\n");
+		printf("[TQFTP] WRQ: unsupported mode '%s', rejecting\n", mode);
+		tftp_send_error_to(sq, TFTP_ERROR_EBADOP, "Only octet mode supported");
 		return;
 	}
 

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -62,8 +62,8 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 {
 	ssize_t len;
 	size_t send_len;
-	char *buf = client->blk_buf;
-	char *p = buf;
+	uint8_t *buf = client->blk_buf;
+	uint8_t *p = buf;
 
 	*p++ = 0;
 	*p++ = OP_DATA;

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -67,6 +67,27 @@ struct tftp_client {
 static struct list_head readers = LIST_INIT(readers);
 static struct list_head writers = LIST_INIT(writers);
 
+static int tftp_send_error(int sock, enum tftp_error code, const char *msg)
+{
+	size_t len;
+	char *buf;
+	int rc;
+
+	len = 4 + strlen(msg) + 1;
+
+	buf = calloc(1, len);
+	if (!buf)
+		return -1;
+
+	*(uint16_t *)buf = htons(OP_ERROR);
+	*(uint16_t *)(buf + 2) = htons(code);
+	strcpy(buf + 4, msg);
+
+	rc = send(sock, buf, len, 0);
+	free(buf);
+	return rc;
+}
+
 static ssize_t tftp_send_data(struct tftp_client *client,
 			      unsigned int block, size_t offset, size_t response_size)
 {
@@ -184,27 +205,6 @@ static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
 	}
 
 	return send(sock, buf, p - buf, 0);
-}
-
-static int tftp_send_error(int sock, enum tftp_error code, const char *msg)
-{
-	size_t len;
-	char *buf;
-	int rc;
-
-	len = 4 + strlen(msg) + 1;
-
-	buf = calloc(1, len);
-	if (!buf)
-		return -1;
-
-	*(uint16_t*)buf = htons(OP_ERROR);
-	*(uint16_t*)(buf + 2) = htons(code);
-	strcpy(buf + 4, msg);
-
-	rc = send(sock, buf, len, 0);
-	free(buf);
-	return rc;
 }
 
 static void parse_options(const char *buf, size_t len, size_t *blksize,

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <libqrtr.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -78,8 +79,23 @@ struct tftp_client {
 	uint16_t blk_expected;
 };
 
+static bool tftp_debug;
+
 static struct list_head readers = LIST_INIT(readers);
 static struct list_head writers = LIST_INIT(writers);
+
+static void log_debug(const char *fmt, ...)
+{
+	va_list ap;
+
+	if (!tftp_debug)
+		return;
+
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+	fflush(stderr);
+}
 
 static int sanitize_path(const char *path)
 {
@@ -180,7 +196,7 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 		send_len = p - buf;
 	}
 
-	// printf("[TQFTP] Sending %zd bytes of DATA\n", send_len);
+	log_debug("[TQFTP] Sending %zd bytes of DATA\n", send_len);
 	return send(client->sock, buf, send_len, 0);
 }
 
@@ -523,7 +539,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 		return;
 	}
 
-	// printf("[TQFTP] new reader added\n");
+	log_debug("[TQFTP] new reader added\n");
 
 	list_add(&readers, &client->node);
 
@@ -666,7 +682,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 		return;
 	}
 
-	// printf("[TQFTP] new writer added\n");
+	log_debug("[TQFTP] new writer added at %d:%d\n", sq->sq_node, sq->sq_port);
 
 	list_add(&writers, &client->node);
 
@@ -738,7 +754,7 @@ static int handle_reader(struct tftp_client *client)
 	}
 
 	last = buf[2] << 8 | buf[3];
-	// printf("[TQFTP] Got ack for %d\n", last);
+	log_debug("[TQFTP] Got ack for %d from %d:%d\n", last, sq.sq_node, sq.sq_port);
 
 	/* We've sent enough data for rsize already */
 	if (last * client->blksize > client->rsize)
@@ -757,7 +773,7 @@ static int handle_reader(struct tftp_client *client)
 			printf("[TQFTP] Sent block %d failed: %zd\n", block + 1, n);
 			break;
 		}
-		// printf("[TQFTP] Sent block %d of %zd\n", block + 1, n);
+		log_debug("[TQFTP] Sent block %d of %zd to %d:%d\n", block + 1, n, sq.sq_node, sq.sq_port);
 		if (n == 0)
 			break;
 		/* We've sent enough data for rsize already */
@@ -856,6 +872,15 @@ static void client_close_and_free(struct tftp_client *client)
 	free(client);
 }
 
+static void print_usage(void)
+{
+	extern const char *__progname;
+
+	fprintf(stderr, "Usage: %s [-d] [-h]\n", __progname);
+	fprintf(stderr, " -d\tPrint detailed debug information\n");
+	fprintf(stderr, " -h\tPrint this usage info\n");
+}
+
 int main(int argc, char **argv)
 {
 	struct tftp_client *client;
@@ -868,8 +893,28 @@ int main(int argc, char **argv)
 	fd_set rfds;
 	int nfds;
 	int opcode;
+	int opt;
 	int ret;
 	int fd;
+
+	while ((opt = getopt(argc, argv, "dh")) != -1) {
+		switch (opt) {
+		case 'd':
+			tftp_debug = true;
+			break;
+		case 'h':
+			print_usage();
+			return 0;
+		default:
+			print_usage();
+			return 1;
+		}
+	}
+
+	if (optind != argc) {
+		print_usage();
+		return 1;
+	}
 
 	fd = qrtr_open(0);
 	if (fd < 0) {
@@ -944,14 +989,14 @@ int main(int argc, char **argv)
 
 				switch (pkt.type) {
 				case QRTR_TYPE_BYE:
-					// fprintf(stderr, "[TQFTP] got bye\n");
+					log_debug("[TQFTP] got bye for %d\n", pkt.node);
 					list_for_each_entry_safe(client, next, &writers, node) {
 						if (client->sq.sq_node == sq.sq_node)
 							client_close_and_free(client);
 					}
 					break;
 				case QRTR_TYPE_DEL_CLIENT:
-					// fprintf(stderr, "[TQFTP] got del_client\n");
+					log_debug("[TQFTP] got del_client for %d:%d\n", pkt.node, pkt.port);
 					list_for_each_entry_safe(client, next, &writers, node) {
 						if (!memcmp(&client->sq, &sq, sizeof(sq)))
 							client_close_and_free(client);
@@ -968,7 +1013,6 @@ int main(int argc, char **argv)
 					handle_rrq(buf, len, &sq);
 					break;
 				case OP_WRQ:
-					// printf("[TQFTP] write\n");
 					handle_wrq(buf, len, &sq);
 					break;
 				case OP_ERROR:

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -417,15 +417,14 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	sock = qrtr_open(0);
 	if (sock < 0) {
-		/* XXX: error */
 		printf("[TQFTP] unable to create new qrtr socket, reject\n");
 		return;
 	}
 
 	ret = connect(sock, (struct sockaddr *)sq, sizeof(*sq));
 	if (ret < 0) {
-		/* XXX: error */
 		printf("[TQFTP] unable to connect new qrtr socket to remote\n");
+		goto out_close_sock;
 		return;
 	}
 
@@ -433,6 +432,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	if (fd < 0) {
 		printf("[TQFTP] unable to open %s (%d), reject\n", filename, errno);
 		tftp_send_error(sock, TFTP_ERROR_ENOENT, "file not found");
+		goto out_close_sock;
 		return;
 	}
 
@@ -455,12 +455,16 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->blk_buf = calloc(1, blksize + 4);
 	if (!client->blk_buf) {
 		printf("[TQFTP] Memory allocation failure\n");
+		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
+		goto out_free_client;
 		return;
 	}
 
 	client->rw_buf = calloc(1, client->rw_buf_size);
 	if (!client->rw_buf) {
 		printf("[TQFTP] Memory allocation failure\n");
+		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
+		goto out_free_blk_buf;
 		return;
 	}
 
@@ -478,6 +482,16 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	} else {
 		tftp_send_data(client, 1, 0, 0);
 	}
+
+	return;
+
+out_free_blk_buf:
+	free(client->blk_buf);
+out_free_client:
+	free(client);
+	close(fd);
+out_close_sock:
+	close(sock);
 }
 
 static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
@@ -551,15 +565,15 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	sock = qrtr_open(0);
 	if (sock < 0) {
-		/* XXX: error */
 		printf("[TQFTP] unable to create new qrtr socket, reject\n");
+		goto out_close_fd;
 		return;
 	}
 
 	ret = connect(sock, (struct sockaddr *)sq, sizeof(*sq));
 	if (ret < 0) {
-		/* XXX: error */
 		printf("[TQFTP] unable to connect new qrtr socket to remote\n");
+		goto out_close_sock;
 		return;
 	}
 
@@ -578,12 +592,16 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->blk_buf = calloc(1, blksize + 4);
 	if (!client->blk_buf) {
 		printf("[TQFTP] Memory allocation failure\n");
+		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
+		goto out_free_client;
 		return;
 	}
 
 	client->rw_buf = calloc(1, client->rw_buf_size);
 	if (!client->rw_buf) {
 		printf("[TQFTP] Memory allocation failure\n");
+		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
+		goto out_free_blk_buf;
 		return;
 	}
 
@@ -601,6 +619,17 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	} else {
 		tftp_send_data(client, 1, 0, 0);
 	}
+
+	return;
+
+out_free_blk_buf:
+	free(client->blk_buf);
+out_free_client:
+	free(client);
+out_close_fd:
+	close(fd);
+out_close_sock:
+	close(sock);
 }
 
 static int handle_reader(struct tftp_client *client)

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -144,7 +144,8 @@ static ssize_t tftp_send_data(struct tftp_client *client,
 
 	len = pread(client->fd, p, client->blksize, offset);
 	if (len < 0) {
-		printf("[TQFTP] failed to read data\n");
+		printf("[TQFTP] failed to read data: %s\n", strerror(errno));
+		tftp_send_error(client->sock, TFTP_ERROR_UNDEF, "Read error");
 		free(buf);
 		return len;
 	}

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -27,8 +27,18 @@ enum {
 	OP_OACK,
 };
 
-enum {
-	ERROR_END_OF_TRANSFER = 9,
+/* RFC 1350: TFTP Error Codes */
+enum tftp_error {
+	TFTP_ERROR_UNDEF = 0,		/* Not defined, see error message */
+	TFTP_ERROR_ENOENT = 1,		/* File not found */
+	TFTP_ERROR_EACCESS = 2,		/* Access violation */
+	TFTP_ERROR_ENOSPACE = 3,	/* Disk full or allocation exceeded */
+	TFTP_ERROR_EBADOP = 4,		/* Illegal TFTP operation */
+	TFTP_ERROR_EBADID = 5,		/* Unknown transfer ID */
+	TFTP_ERROR_EEXISTS = 6,		/* File already exists */
+	TFTP_ERROR_ENOUSER = 7,		/* No such user */
+	TFTP_ERROR_EOPTNEG = 8,		/* Option negotiation failed (RFC 2347) */
+	ERROR_END_OF_TRANSFER = 9,	/* Custom: End of transfer (not an error) */
 };
 
 struct tftp_client {
@@ -176,7 +186,7 @@ static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
 	return send(sock, buf, p - buf, 0);
 }
 
-static int tftp_send_error(int sock, int code, const char *msg)
+static int tftp_send_error(int sock, enum tftp_error code, const char *msg)
 {
 	size_t len;
 	char *buf;
@@ -296,7 +306,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	fd = translate_open(filename, O_RDONLY);
 	if (fd < 0) {
 		printf("[TQFTP] unable to open %s (%d), reject\n", filename, errno);
-		tftp_send_error(sock, 1, "file not found");
+		tftp_send_error(sock, TFTP_ERROR_ENOENT, "file not found");
 		return;
 	}
 
@@ -543,7 +553,7 @@ static int handle_writer(struct tftp_client *client)
 	block = buf[2] << 8 | buf[3];
 	if (opcode != OP_DATA) {
 		printf("[TQFTP] Expected DATA opcode, got %d\n", opcode);
-		tftp_send_error(client->sock, 4, "Expected DATA opcode");
+		tftp_send_error(client->sock, TFTP_ERROR_EBADOP, "Expected DATA opcode");
 		return -1;
 	}
 
@@ -556,7 +566,7 @@ static int handle_writer(struct tftp_client *client)
 
 		printf("[TQFTP] Block number out of sequence: %d (expected %d)\n",
 			 block, blk_expected);
-		tftp_send_error(client->sock, 4, "Block number out of sequence");
+		tftp_send_error(client->sock, TFTP_ERROR_EBADOP, "Block number out of sequence");
 
 		/* Set blk_expected to beginning of current window */
 		if ((blk_expected % client->wsize) == 0)

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -81,6 +81,23 @@ struct tftp_client {
 static struct list_head readers = LIST_INIT(readers);
 static struct list_head writers = LIST_INIT(writers);
 
+static int sanitize_path(const char *path)
+{
+	const char *p;
+
+	/* Check for "../" or "/../" */
+	for (p = path; *p; p++) {
+		if (p[0] == '.' && p[1] == '.' && p[2] == '/') {
+			if (p == path || p[-1] == '/') {
+				printf("[TQFTP] Directory traversal rejected: %s\n", path);
+				return -1;
+			}
+		}
+	}
+
+	return 0;
+}
+
 static int tftp_send_error(int sock, enum tftp_error code, const char *msg)
 {
 	size_t len;
@@ -401,6 +418,12 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 		return;
 	}
 
+	/* Validate filename for path traversal attacks */
+	if (sanitize_path(filename) < 0) {
+		tftp_send_error_to(sq, TFTP_ERROR_EACCESS, "Access violation");
+		return;
+	}
+
 	if (p < buf + len) {
 		do_oack = true;
 		ret = parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
@@ -551,6 +574,12 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	}
 
 	printf("[TQFTP] WRQ: %s (%s)\n", filename, mode);
+
+	/* Validate filename for path traversal attacks */
+	if (sanitize_path(filename) < 0) {
+		tftp_send_error_to(sq, TFTP_ERROR_EACCESS, "Access violation");
+		return;
+	}
 
 	if (p < buf + len) {
 		do_oack = true;


### PR DESCRIPTION
A variety of todo items related to sanity checking inputs, missing error message, etc has been lingering in the tqftpserver implementation.
Resolve some of these, and tidy up the mishmash of log prints, to take a step towards a more reasonable level of quality.