### PR TITLE
tftp: ACK short DATA packets in WRQ window mode

### DIFF
--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -869,8 +869,9 @@ static int handle_writer(struct tftp_client *client)
 	memcpy(client->rw_buf + client->blk_offset, buf, payload);
 	client->blk_offset += payload;
 
-	/* Write to file if all the wsize blocks are recieved */
-	if (block % client->wsize == 0) {
+	/* Write to file if all the wsize blocks are recieved
+	 * or received buffer that is less than blksize */
+	if ((block % client->wsize == 0) || (payload < client->blksize)) {
 		ret = write(client->fd, client->rw_buf, client->blk_offset);
 		if (ret < 0) {
 			log_err("failed to write data: %s\n", strerror(errno));


### PR DESCRIPTION
When receiving DATA packets during a WRQ transfer, the payload size may be smaller than the negotiated blksize. This indicates the final DATA packet, even if fewer than wsize packets have been received.

ACK such packets immediately instead of waiting for a full window, so the transfer can complete correctly.