### PR TITLE
translate: add persistent path for read-write and fix read-only search path

### DIFF
--- a/tqftpserv.service.in
+++ b/tqftpserv.service.in
@@ -4,7 +4,7 @@ Description=QRTR TFTP service
 [Service]
 ExecStart=@prefix@/bin/tqftpserv
 Restart=always
+StateDirectory=tqftpserv
 
 [Install]
 WantedBy=multi-user.target
-

--- a/translate.c
+++ b/translate.c
@@ -24,7 +24,7 @@
 
 #ifndef ANDROID
 #define FIRMWARE_BASE	"/lib/firmware/"
-#define TQFTPSERV_TMP	"/tmp/tqftpserv"
+#define TQFTPSERV_TMP	"/var/lib/tqftpserv"
 #else
 #define FIRMWARE_BASE	"/vendor/firmware/"
 #define TQFTPSERV_TMP	"/data/vendor/tmp/tqftpserv"

--- a/translate.c
+++ b/translate.c
@@ -24,10 +24,10 @@
 
 #ifndef ANDROID
 #define FIRMWARE_BASE	"/lib/firmware/"
-#define TQFTPSERV_TMP	"/var/lib/tqftpserv"
+#define TQFTPSERV_RW_DIR	"/var/lib/tqftpserv"
 #else
 #define FIRMWARE_BASE	"/vendor/firmware/"
-#define TQFTPSERV_TMP	"/data/vendor/tmp/tqftpserv"
+#define TQFTPSERV_RW_DIR	"/data/vendor/tmp/tqftpserv"
 #endif
 
 static int open_maybe_compressed(const char *path);
@@ -163,7 +163,7 @@ static int translate_readonly(const char *file)
 }
 
 /**
- * translate_readwrite() - open "file" from a temporary directory
+ * translate_readwrite() - open "file" from the persistent readwrite directory
  * @file:	relative path of the requested file, with /readwrite/ stripped
  * @flags:	flags to be passed to open(2)
  *
@@ -175,15 +175,15 @@ static int translate_readwrite(const char *file, int flags)
 	int ret;
 	int fd;
 
-	ret = mkdir(TQFTPSERV_TMP, 0700);
+	ret = mkdir(TQFTPSERV_RW_DIR, 0700);
 	if (ret < 0 && errno != EEXIST) {
-		warn("failed to create temporary tqftpserv directory");
+		warn("failed to create tqftpserv readwrite directory");
 		return -1;
 	}
 
-	base = open(TQFTPSERV_TMP, O_RDONLY | O_DIRECTORY);
+	base = open(TQFTPSERV_RW_DIR, O_RDONLY | O_DIRECTORY);
 	if (base < 0) {
-		warn("failed top open temporary tqftpserv directory");
+		warn("failed to open tqftpserv readwrite directory");
 		return -1;
 	}
 

--- a/translate.c
+++ b/translate.c
@@ -21,6 +21,8 @@
 #define READONLY_PATH	"/readonly/firmware/image/"
 #define READWRITE_PATH	"/readwrite/"
 #define UPDATES_DIR	"updates/"
+#define READONLY_FW_BASE	"/readonly/firmware/"
+#define READONLY_MODEM_PATH	READONLY_FW_BASE "modem_pr"
 
 #ifndef ANDROID
 #define FIRMWARE_BASE	"/lib/firmware/"
@@ -198,15 +200,17 @@ static int translate_readwrite(const char *file, int flags)
 /**
  * translate_open() - open file after translating path
  *
-
- * Strips /readonly/firmware/image and search among remoteproc firmware.
- * Replaces /readwrite with a temporary directory.
-
+ * Strips /readonly/firmware/image/ and searches among remoteproc firmware.
+ * Strips /readonly/firmware/modem_pr and searches among remoteproc firmware
+ * using the modem_pr relative path (e.g., maps to READONLY_FW_BASE/<fw_dir>/modem_pr/...).
+ * Replaces /readwrite/ with a persistent directory.
  */
 int translate_open(const char *path, int flags)
 {
 	if (!strncmp(path, READONLY_PATH, strlen(READONLY_PATH)))
 		return translate_readonly(path + strlen(READONLY_PATH));
+	else if (!strncmp(path, READONLY_MODEM_PATH, strlen(READONLY_MODEM_PATH)))
+		return translate_readonly(path + strlen(READONLY_FW_BASE));
 	else if (!strncmp(path, READWRITE_PATH, strlen(READWRITE_PATH)))
 		return translate_readwrite(path + strlen(READWRITE_PATH), flags);
 


### PR DESCRIPTION
In TFTP RRQ, modem is asking for fw image with path **/readonly/firmware/modem_pr/so/**
Server is not able to process this request because it is expecting RRQ path to start with **/readonly/firmware/image/** and doesn't call **translate_readonly.**

READONLY_REQ macro is added to search in RRQ and call translate_readonly when matched.  With this change Modem is able to boot and link is up, Modem images are stored in below folder structure in target:
**/lib/firmware/qcom/qcm6490/modem_pr/so/**