### PR TITLE
zstd-decompress: don't log 'no such file' entries

### DIFF
--- a/zstd-decompress.c
+++ b/zstd-decompress.c
@@ -30,7 +30,8 @@ int zstd_decompress_file(const char *filename)
 	/* Figure out the size of the file. */
 	struct stat file_stat;
 	if (stat(filename, &file_stat) == -1) {
-		fprintf(stderr, "stat %s failed (%s)\n", filename, strerror(errno));
+		if (errno != ENOENT)
+			fprintf(stderr, "stat %s failed (%s)\n", filename, strerror(errno));
 		return -1;
 	}
 


### PR DESCRIPTION
There is little point in logging all the predictable "no such file or directory" erorrs while the daemon is actually checking if the compressed file exists or not. Silent them up to prevent filling the log with the error-looking messages which don't singify any actual error.