### PR TITLE
translate: support /readonly/vendor/firmware/ paths

### DIFF
--- a/translate.c
+++ b/translate.c
@@ -23,6 +23,8 @@
 #define UPDATES_DIR	"updates/"
 #define READONLY_FW_BASE	"/readonly/firmware/"
 #define READONLY_MODEM_PATH	READONLY_FW_BASE "modem_pr"
+#define READONLY_VENDOR_PATH		"/readonly/vendor/firmware/"
+#define READONLY_VENDOR_MNT_PATH	"/readonly/vendor/firmware_mnt/image/"
 
 #ifndef ANDROID
 #define FIRMWARE_BASE	"/lib/firmware/"
@@ -203,6 +205,8 @@ static int translate_readwrite(const char *file, int flags)
  * Strips /readonly/firmware/image/ and searches among remoteproc firmware.
  * Strips /readonly/firmware/modem_pr and searches among remoteproc firmware
  * using the modem_pr relative path (e.g., maps to READONLY_FW_BASE/<fw_dir>/modem_pr/...).
+ * Strips /readonly/vendor/firmware/ and /readonly/vendor/firmware_mnt/image/
+ * and searches among remoteproc firmware.
  * Replaces /readwrite/ with a persistent directory.
  */
 int translate_open(const char *path, int flags)
@@ -213,6 +217,10 @@ int translate_open(const char *path, int flags)
 		return translate_readonly(path + strlen(READONLY_FW_BASE));
 	else if (!strncmp(path, READWRITE_PATH, strlen(READWRITE_PATH)))
 		return translate_readwrite(path + strlen(READWRITE_PATH), flags);
+	else if (!strncmp(path, READONLY_VENDOR_MNT_PATH, strlen(READONLY_VENDOR_MNT_PATH)))
+		return translate_readonly(path + strlen(READONLY_VENDOR_MNT_PATH));
+	else if (!strncmp(path, READONLY_VENDOR_PATH, strlen(READONLY_VENDOR_PATH)))
+		return translate_readonly(path + strlen(READONLY_VENDOR_PATH));
 
 	fprintf(stderr, "invalid path %s, rejecting\n", path);
 	errno = ENOENT;


### PR DESCRIPTION
# translate: support /readonly/vendor/firmware/ paths

## Summary

Some Qualcomm modem firmware — Xiaomi raphael on sm8150 (Mi 9T / Redmi K20 Pro), db845c (per #7), and likely other sm8150-class Xiaomi/OnePlus devices — request their protection-domain firmware blobs (e.g. `wlanmdsp.mbn`) via TFTP-over-QRTR using Android-style vendor partition paths. tqftpserv currently rejects these requests with `invalid path ... rejecting`, so the PD never loads, the corresponding QMI service never registers, and the consuming kernel driver hangs.

This PR adds the two prefixes called out in #7 and delegates both to the existing `translate_readonly()` (the remoteproc-firmware-dir search), matching how every other readonly prefix is handled. Refs #7 (partial — adds the two prefixes db845c was hitting; doesn't introduce a general mapping system).

## Reviewer-requested change applied

Initial revision of this PR added a `translate_vendor()` helper that tried `FIRMWARE_BASE/<file>` first and then fell back to `translate_readonly()`. Per @lumag's review, this introduced an inconsistency with the other readonly prefix handling — simplified to delegate directly to `translate_readonly()` for both new prefixes. Distros now need to ensure that the requested blob is reachable from a remoteproc's firmware= attribute directory (i.e. under `/lib/firmware/<dirname of remoteproc fw>/<file>`).

For postmarketOS on `xiaomi-raphael` specifically: the `firmware-xiaomi-raphael-wlan` aport currently ships `wlanmdsp.mbn` at `/lib/firmware/wlanmdsp.mbn` (top-level). That needs to be installed (or symlinked) into `/lib/firmware/qcom/sm8150/xiaomi/raphael/` alongside `modem.mbn`. Coordinated in https://gitlab.postmarketos.org/postmarketOS/pmaports/-/work_items/4554.

## Concrete failure mode reproduced on Xiaomi Mi 9T / Redmi K20 Pro (raphael, sm8150)

postmarketOS edge, kernel 6.16.9-sm8150.

Before any fix:
```
$ journalctl -u tqftpserv -b | grep wlanmdsp
tqftpserv[741]: invalid path /readonly/vendor/firmware/wlanmdsp.mbn, rejecting

$ qrtr-lookup | grep -i wlan        # WLAN_FW QMI service (id 69) absent
(empty)

$ dmesg | grep ath10k
ath10k_snoc 18800000.wifi: supply vdd-3.3-ch1 not found, using dummy regulator
(... nothing further — probe halts ...)

$ ls /sys/class/ieee80211/          # no PHY
(empty)
```

With the (initial fast-path version of this) patch plus the file in the right place:
```
$ qrtr-lookup | grep -i wlan
       69       1        0    0    88 ATH10k WLAN firmware service

$ dmesg | grep ath10k
ath10k_snoc 18800000.wifi: qmi chip_id 0x30224 chip_family 0x4001 board_id 0xff
ath10k_snoc 18800000.wifi: qmi fw_version 0x300980f2 ... WLAN.HL.3.0.c2-00242-QCAHLSWMTPLZ-1
ath10k_snoc 18800000.wifi: wcn3990 hw1.0 target 0x00000008 chip_id 0x00000000
ath10k_snoc 18800000.wifi: firmware ver  api 5 features wowlan,mgmt-tx-by-reference,non-bmi
ath10k_snoc 18800000.wifi: htt-ver 3.70 wmi-op 4 htt-op 3 cal file max-sta 32 raw 0 hwcrypto 1

$ ls /sys/class/ieee80211/
phy0

$ iw dev wlan0 scan | grep -E '^BSS|SSID:' | head
BSS e4:7e:9a:64:8e:c0(on wlan0)
	SSID: CU_rKyk
(... more APs ...)
```

(End-to-end verification was done with the earlier, fast-path version of the patch on the K20; the simplified-per-review version produces the same result when paired with the firmware-location fix being coordinated in the pmaports issue.)

## Author

`Astro Enigma` <astronazer@gmail.com>. Tested on Xiaomi Mi 9T / Redmi K20 Pro running postmarketOS edge (kernel 6.16.9-sm8150).
