### PR TITLE
fix: add path validation in tqftpserv.c

### DIFF
--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -146,7 +146,7 @@ static int tftp_send_error(int sock, enum tftp_error code, const char *msg)
 
 	*(uint16_t *)buf = htons(OP_ERROR);
 	*(uint16_t *)(buf + 2) = htons(code);
-	strcpy(buf + 4, msg);
+	memcpy(buf + 4, msg, len - 4);
 
 	rc = send(sock, buf, len, 0);
 	free(buf);

--- a/translate.c
+++ b/translate.c
@@ -177,6 +177,13 @@ static int translate_readwrite(const char *file, int flags)
 	int ret;
 	int fd;
 
+	/* Reject directory traversal attempts */
+	if (strstr(file, "..")) {
+		warn("path traversal attempt rejected: %s", file);
+		errno = EACCES;
+		return -1;
+	}
+
 	ret = mkdir(TQFTPSERV_RW_DIR, 0700);
 	if (ret < 0 && errno != EEXIST) {
 		warn("failed to create tqftpserv readwrite directory");


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `tqftpserv.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tqftpserv.c:537` |
| **CWE** | CWE-22 |

**Description**: The TFTP server processes write requests (WRQ) without validating or canonicalizing the requested filename. Combined with the unsanitized path concatenation in translate.c, an attacker can supply a filename containing directory traversal sequences (e.g., '../../etc/passwd') to write arbitrary content to any location on the filesystem accessible to the service process. No authorization check exists to verify whether a client is permitted to write firmware files.

## Changes
- `translate.c`
- `tqftpserv.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
