### PR TITLE
Add GitHub Actions build CI with zstd autodetection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,65 @@ jobs:
 
     - name: Install
       run: ninja -C build install
+
+  android:
+    name: Android
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a, armeabi-v7a, x86_64]
+
+    env:
+      NDK_VERSION: r27d
+      QRTR_REF: v1.2
+      API: "24"
+      ABI: ${{ matrix.abi }}
+      QRTR_SRC: ${{ github.workspace }}/qrtr
+      QRTR_PREFIX: ${{ github.workspace }}/qrtr-install/${{ matrix.abi }}
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v5
+
+    - name: Install build tools
+      run: |
+        sudo apt update
+        sudo apt install -y --no-install-recommends meson ninja-build pkg-config
+
+    - name: Cache Android NDK
+      id: ndk-cache
+      uses: actions/cache@v4
+      with:
+        path: android-ndk-${{ env.NDK_VERSION }}
+        key: ndk-${{ env.NDK_VERSION }}-linux
+
+    - name: Download Android NDK
+      if: steps.ndk-cache.outputs.cache-hit != 'true'
+      run: |
+        curl -sSLO https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip
+        unzip -q android-ndk-${NDK_VERSION}-linux.zip
+        rm android-ndk-${NDK_VERSION}-linux.zip
+
+    - name: Cache libqrtr
+      id: qrtr-cache
+      uses: actions/cache@v4
+      with:
+        path: qrtr-install/${{ matrix.abi }}
+        key: qrtr-android-${{ matrix.abi }}-${{ env.QRTR_REF }}-ndk-${{ env.NDK_VERSION }}
+
+    - name: Checkout qrtr
+      if: steps.qrtr-cache.outputs.cache-hit != 'true'
+      uses: actions/checkout@v5
+      with:
+        repository: linux-msm/qrtr
+        ref: ${{ env.QRTR_REF }}
+        path: qrtr
+
+    - name: Build for Android
+      run: |
+        export ANDROID_NDK="$GITHUB_WORKSPACE/android-ndk-${NDK_VERSION}"
+        ./ci/android.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# Loosely based on the cdba project CI:
+#   https://github.com/linux-msm/cdba
+#
+name: "Builds"
+on:
+  pull_request:
+  push:
+  schedule:
+    # Run at 1:01 PM, every Tuesday
+    - cron: '1 13 * * 2'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        # zstd support is autodetected: the "enabled" variant installs the
+        # libzstd development package, the "disabled" one does not.
+        zstd: [enabled, disabled]
+        container:
+          - alpine:latest
+          - archlinux:latest
+          - debian:testing
+          - debian:stable
+          - fedora:latest
+          - ubuntu:latest
+          - ubuntu:noble
+        exclude:
+          # zstd ships in the Arch base image and cannot be removed, so the
+          # "disabled" build cannot be exercised there.
+          - container: archlinux:latest
+            zstd: disabled
+
+    container:
+      image: ${{ matrix.container }}
+      env:
+        CC: ${{ matrix.compiler }}
+        ZSTD: ${{ matrix.zstd }}
+
+    steps:
+    - name: Show OS
+      run: cat /etc/os-release
+
+    - name: Git checkout
+      uses: actions/checkout@v5
+
+    - name: Install additional packages
+      run: |
+        INSTALL=${{ matrix.container }}
+        INSTALL="${INSTALL%%:*}"
+        INSTALL="${INSTALL%%/*}"
+        ./ci/$INSTALL.sh
+
+    - name: Compiler version
+      run: $CC --version
+
+    - name: Meson setup
+      run: meson setup --errorlogs --werror . build
+
+    - name: Compile
+      run: ninja -C build
+
+    - name: Verify zstd autodetection
+      run: ./ci/check-zstd.sh
+
+    - name: Install
+      run: ninja -C build install

--- a/ci/alpine.sh
+++ b/ci/alpine.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# Install build dependencies on Alpine Linux.
+
+set -ex
+
+# build-base pulls in binutils (the linker/assembler) and the musl headers,
+# which clang needs as well; add clang on top when it is the compiler.
+PKGS_CC=""
+case $CC in
+	clang*)
+		PKGS_CC="clang"
+	;;
+esac
+
+PKGS_ZSTD=""
+if [ "$ZSTD" = "enabled" ]; then
+	PKGS_ZSTD="zstd-dev"
+fi
+
+apk add \
+	build-base \
+	pkgconf \
+	meson \
+	ninja \
+	qrtr-dev \
+	$PKGS_ZSTD \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/ci/android.sh
+++ b/ci/android.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# Cross-build tqftpserv (and its libqrtr dependency) for Android using the NDK.
+#
+# Expects the following environment variables:
+#   ABI          - Android ABI (arm64-v8a, armeabi-v7a, x86_64)
+#   API          - Android API level to target
+#   ANDROID_NDK  - path to an unpacked Android NDK
+#   QRTR_SRC     - path to a checked-out qrtr source tree
+#   QRTR_PREFIX  - prefix into which libqrtr is (or was) installed
+
+set -ex
+
+TOOLCHAIN="$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64"
+
+case "$ABI" in
+	arm64-v8a)
+		CPU_FAMILY=aarch64
+		CPU=aarch64
+		TRIPLE=aarch64-linux-android
+		ELF_MACHINE=AArch64
+	;;
+	armeabi-v7a)
+		CPU_FAMILY=arm
+		CPU=armv7a
+		TRIPLE=armv7a-linux-androideabi
+		ELF_MACHINE=ARM
+	;;
+	x86_64)
+		CPU_FAMILY=x86_64
+		CPU=x86_64
+		TRIPLE=x86_64-linux-android
+		ELF_MACHINE=X86-64
+	;;
+	*)
+		echo "Unknown ABI '$ABI'" >&2
+		exit 1
+	;;
+esac
+
+# The per-ABI clang wrapper already selects the correct target and sysroot, so
+# the cross file does not need to spell those out.
+cat > android-cross.txt <<EOF
+[binaries]
+c = '$TOOLCHAIN/bin/${TRIPLE}${API}-clang'
+ar = '$TOOLCHAIN/bin/llvm-ar'
+strip = '$TOOLCHAIN/bin/llvm-strip'
+pkg-config = 'pkg-config'
+
+[host_machine]
+system = 'android'
+cpu_family = '$CPU_FAMILY'
+cpu = '$CPU'
+endian = 'little'
+
+[properties]
+pkg_config_libdir = '$QRTR_PREFIX/lib/pkgconfig'
+EOF
+cat android-cross.txt
+
+# Build and install libqrtr, unless it was already restored from the cache.
+if [ ! -f "$QRTR_PREFIX/lib/pkgconfig/qrtr.pc" ]; then
+	meson setup --cross-file android-cross.txt \
+		--prefix="$QRTR_PREFIX" --libdir=lib \
+		"$QRTR_SRC" "$QRTR_SRC/build-$ABI"
+	ninja -C "$QRTR_SRC/build-$ABI" install
+fi
+
+meson setup --errorlogs --werror --cross-file android-cross.txt . build
+ninja -C build
+
+# Confirm the resulting binary really is for the requested ABI.
+"$TOOLCHAIN/bin/llvm-readelf" -h build/tqftpserv | grep -q "Machine:.*$ELF_MACHINE"
+echo "Android build for $ABI ($ELF_MACHINE) succeeded"

--- a/ci/archlinux.sh
+++ b/ci/archlinux.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# Install build dependencies on Arch Linux.
+#
+# qrtr is only packaged in the AUR, which is not available in the CI
+# container, so build and install it from source.
+
+set -ex
+
+PKGS_CC="gcc"
+case $CC in
+	clang*)
+		PKGS_CC="clang"
+	;;
+esac
+
+# zstd ships as part of the Arch base image and cannot be removed, so there
+# is no "disabled" variant to install here.
+pacman -Syu --noconfirm \
+	pkgconf \
+	meson \
+	ninja \
+	git \
+	zstd \
+	$PKGS_CC
+
+QRTR_SRC=$(mktemp -d)
+git clone --depth 1 https://github.com/linux-msm/qrtr "$QRTR_SRC"
+meson setup --prefix=/usr "$QRTR_SRC" "$QRTR_SRC/build"
+ninja -C "$QRTR_SRC/build"
+ninja -C "$QRTR_SRC/build" install
+rm -rf "$QRTR_SRC"
+
+echo "Install finished: $0"

--- a/ci/check-zstd.sh
+++ b/ci/check-zstd.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# Verify that zstd support was autodetected as expected: zstd-decompress.c is
+# only compiled when libzstd is available.
+
+set -eu
+
+OBJ=build/tqftpserv.p/zstd-decompress.c.o
+
+case "$ZSTD" in
+enabled)
+	if [ ! -f "$OBJ" ]; then
+		echo "ERROR: expected zstd support, but zstd-decompress.c was not built"
+		exit 1
+	fi
+	;;
+disabled)
+	if [ -f "$OBJ" ]; then
+		echo "ERROR: expected no zstd support, but zstd-decompress.c was built"
+		exit 1
+	fi
+	;;
+*)
+	echo "ERROR: unexpected ZSTD value '$ZSTD'"
+	exit 1
+	;;
+esac
+
+echo "zstd support check ($ZSTD) passed"

--- a/ci/debian.sh
+++ b/ci/debian.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# Install build dependencies on Debian and Ubuntu.
+
+set -ex
+
+apt update
+
+# Some distros might pull tzdata which asks questions
+export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+
+PKGS_CC="build-essential"
+case $CC in
+	clang*)
+		PKGS_CC="clang"
+	;;
+esac
+
+PKGS_ZSTD=""
+if [ "$ZSTD" = "enabled" ]; then
+	PKGS_ZSTD="libzstd-dev"
+fi
+
+apt install -y --no-install-recommends \
+	pkg-config \
+	meson \
+	ninja-build \
+	libqrtr-dev \
+	$PKGS_ZSTD \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/ci/fedora.sh
+++ b/ci/fedora.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# Install build dependencies on Fedora.
+
+set -ex
+
+PKGS_CC="gcc"
+case $CC in
+	clang*)
+		PKGS_CC="clang"
+	;;
+esac
+
+PKGS_ZSTD=""
+if [ "$ZSTD" = "enabled" ]; then
+	PKGS_ZSTD="libzstd-devel"
+fi
+
+dnf -y install \
+	pkgconf-pkg-config \
+	meson \
+	ninja-build \
+	qrtr-devel \
+	$PKGS_ZSTD \
+	$PKGS_CC
+
+echo "Install finished: $0"

--- a/ci/ubuntu.sh
+++ b/ci/ubuntu.sh
@@ -1,0 +1,1 @@
+debian.sh

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,10 @@ project('tqftpserv',
 
 prefix = get_option('prefix')
 
+if host_machine.system() == 'android'
+  add_project_arguments('-DANDROID', language : 'c')
+endif
+
 tqftpserv_srcs = ['translate.c',
                   'tqftpserv.c']
 tqftpserv_deps = []

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,8 @@ elif systemd.found()
   systemd_system_unit_dir = systemd.get_variable(
     pkgconfig : 'systemdsystemunitdir',
     pkgconfig_define: ['prefix', prefix])
+else
+  systemd_system_unit_dir = ''
 endif
 
 qrtr_dep = dependency('qrtr')

--- a/meson.build
+++ b/meson.build
@@ -10,8 +10,16 @@ project('tqftpserv',
 
 prefix = get_option('prefix')
 
-zstd_dep = dependency('libzstd')
-add_project_arguments('-DHAVE_ZSTD', language : 'c')
+tqftpserv_srcs = ['translate.c',
+                  'tqftpserv.c']
+tqftpserv_deps = []
+
+zstd_dep = dependency('libzstd', required : false)
+if zstd_dep.found()
+  add_project_arguments('-DHAVE_ZSTD', language : 'c')
+  tqftpserv_srcs += 'zstd-decompress.c'
+  tqftpserv_deps += zstd_dep
+endif
 
 # Not required to build the executable,
 # only to automatically retrieve the install dir for unit files
@@ -27,13 +35,11 @@ else
 endif
 
 qrtr_dep = dependency('qrtr')
+tqftpserv_deps += qrtr_dep
 
-tqftpserv_srcs = ['translate.c',
-                  'tqftpserv.c',
-                  'zstd-decompress.c']
 executable('tqftpserv',
            tqftpserv_srcs,
-           dependencies : [qrtr_dep, zstd_dep],
+           dependencies : tqftpserv_deps,
            install : true)
 
 if systemd_system_unit_dir != ''

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,12 @@ else
   systemd_system_unit_dir = ''
 endif
 
-qrtr_dep = dependency('qrtr')
+qrtr_dep = dependency('qrtr', required : false)
+if not qrtr_dep.found()
+  # Support old libqrtr that does not ship a qrtr.pc pkg-config file.
+  cc = meson.get_compiler('c')
+  qrtr_dep = cc.find_library('qrtr', has_headers : 'libqrtr.h')
+endif
 tqftpserv_deps += qrtr_dep
 
 executable('tqftpserv',

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -313,7 +313,7 @@ static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
 		memcpy(p, "seek", 5);
 		p += 5;
 
-		n = snprintf(p, end - p, "%zd", *seek);
+		n = snprintf(p, end - p, "%zd", (size_t)*seek);
 		if (n < 0 || n >= end - p)
 			return -1;
 		p += n;

--- a/zstd-decompress.h
+++ b/zstd-decompress.h
@@ -7,6 +7,7 @@
 #define __ZSTD_DECOMPRESS_H__
 
 #include <stdbool.h>
+#include <stdio.h>
 
 #ifdef HAVE_ZSTD
 int zstd_decompress_file(const char *filename);


### PR DESCRIPTION
Add a GitHub Actions build workflow, modeled on the [cdba](https://github.com/linux-msm/cdba) project's CI, that builds tqftpserv across a matrix of distributions (Alpine, Arch, Debian, Fedora, Ubuntu) and compilers (gcc, clang).

To exercise both compression configurations, libzstd is turned into an optional, autodetected dependency and the matrix toggles it on and off (by installing the libzstd development package or not). A small check verifies that the autodetection matched the requested variant.

qrtr is installed from the distribution packages where available; on Arch (where it only exists in the AUR) it is built from source. zstd ships in the Arch base image and cannot be removed, so the zstd-disabled variant is excluded there.

Along the way this also fixes a latent meson bug where `systemd_system_unit_dir` could be referenced while undefined on systems without a systemd pkg-config file (e.g. musl-based distros), which would otherwise break the CI build.

Note: the per-distro package names and the Arch from-source qrtr build have not been exercised in a live CI run yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)