### PR TITLE
Several misc fixes, including possible path traversal

### DIFF
--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -427,7 +427,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	unsigned int timeoutms = 1000;
 	size_t rsize = 0;
 	size_t wsize = 1;
-	off_t seek = 0;
+	off_t seek = -1;
 	bool do_oack = false;
 	int sock;
 	int ret;
@@ -533,7 +533,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->rsize = rsize;
 	client->wsize = wsize;
 	client->timeoutms = timeoutms;
-	client->seek = seek;
+	client->seek = seek < 0 ? 0 : seek;
 	client->rw_buf_size = blksize * wsize;
 
 	client->blk_buf = calloc(1, blksize + 4);
@@ -558,11 +558,11 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	if (do_oack) {
 		tftp_send_oack(client->sock, &blksize,
-			       tsize ? (size_t*)&tsize : NULL,
+			       (size_t *)&tsize,
 			       wsize ? &wsize : NULL,
 			       &client->timeoutms,
 			       rsize ? &rsize : NULL,
-			       seek ? &seek : NULL);
+			       seek >= 0 ? &seek : NULL);
 	} else {
 		tftp_send_data(client, 1, 0, 0);
 	}
@@ -591,7 +591,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	unsigned int timeoutms = 1000;
 	size_t rsize = 0;
 	size_t wsize = 1;
-	off_t seek = 0;
+	off_t seek = -1;
 	bool do_oack = false;
 	int sock;
 	int ret;
@@ -683,7 +683,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	client->rsize = rsize;
 	client->wsize = wsize;
 	client->timeoutms = timeoutms;
-	client->seek = seek;
+	client->seek = seek < 0 ? 0 : seek;
 	client->rw_buf_size = blksize * wsize;
 	client->blk_expected = 1;
 
@@ -709,11 +709,11 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 
 	if (do_oack) {
 		tftp_send_oack(client->sock, &blksize,
-			       tsize ? (size_t*)&tsize : NULL,
+			       (size_t *)&tsize,
 			       wsize ? &wsize : NULL,
 			       &client->timeoutms,
 			       rsize ? &rsize : NULL,
-			       seek ? &seek : NULL);
+			       seek >= 0 ? &seek : NULL);
 	} else {
 		tftp_send_data(client, 1, 0, 0);
 	}

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -773,6 +773,13 @@ static int handle_reader(struct tftp_client *client)
 		return -1;
 	}
 
+	/* Need at least opcode and block/error fields */
+	if (len < 4) {
+		log_err("Received short packet (%zd bytes) from %d:%d\n",
+			len, sq.sq_node, sq.sq_port);
+		return -1;
+	}
+
 	opcode = buf[0] << 8 | buf[1];
 	if (opcode == OP_ERROR) {
 		buf[len] = '\0';
@@ -844,6 +851,17 @@ static int handle_writer(struct tftp_client *client)
 	if (sq.sq_node != client->sq.sq_node ||
 	    sq.sq_port != client->sq.sq_port)
 		return -1;
+
+	/*
+	 * Need at least opcode and block fields; without this a short packet
+	 * makes payload (len - 4) underflow and the memcpy below runs wild.
+	 */
+	if (len < 4) {
+		log_err("Received short packet (%zd bytes) from %d:%d\n",
+			len, sq.sq_node, sq.sq_port);
+		tftp_send_error(client->sock, TFTP_ERROR_EBADOP, "Malformed packet");
+		return -1;
+	}
 
 	opcode = buf[0] << 8 | buf[1];
 	block = buf[2] << 8 | buf[3];

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -758,7 +758,8 @@ static int handle_reader(struct tftp_client *client)
 	int ret;
 
 	sl = sizeof(sq);
-	len = recvfrom(client->sock, buf, sizeof(buf), 0, (void *)&sq, &sl);
+	/* Reserve one byte so the ERROR message can be NUL-terminated below */
+	len = recvfrom(client->sock, buf, sizeof(buf) - 1, 0, (void *)&sq, &sl);
 	if (len < 0) {
 		ret = -errno;
 		if (ret != -ENETRESET)
@@ -1025,7 +1026,8 @@ int main(int argc, char **argv)
 
 		if (FD_ISSET(fd, &rfds)) {
 			sl = sizeof(sq);
-			len = recvfrom(fd, buf, sizeof(buf), 0, (void *)&sq, &sl);
+			/* Reserve one byte so an ERROR message can be NUL-terminated */
+			len = recvfrom(fd, buf, sizeof(buf) - 1, 0, (void *)&sq, &sl);
 			if (len < 0) {
 				ret = -errno;
 				if (ret != -ENETRESET)

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -535,6 +535,12 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	}
 
 	client = calloc(1, sizeof(*client));
+	if (!client) {
+		log_err("Memory allocation failure\n");
+		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
+		/* client is NULL; free(NULL) is a no-op, fd and sock get closed */
+		goto out_free_client;
+	}
 	client->sq = *sq;
 	client->sock = sock;
 	client->fd = fd;
@@ -679,6 +685,12 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	}
 
 	client = calloc(1, sizeof(*client));
+	if (!client) {
+		log_err("Memory allocation failure\n");
+		tftp_send_error(sock, TFTP_ERROR_UNDEF, "Resources temporary unavailable");
+		/* client is NULL; free(NULL) is a no-op, fd and sock get closed */
+		goto out_free_client;
+	}
 	client->sq = *sq;
 	client->sock = sock;
 	client->fd = fd;

--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -117,21 +117,6 @@ static void log_info(const char *fmt, ...)
 	fflush(stderr);
 }
 
-static int sanitize_path(const char *path)
-{
-	const char *p;
-
-	/* Check for "../" or "/../" */
-	for (p = path; *p; p++) {
-		if (p[0] == '.' && p[1] == '.' && p[2] == '/') {
-			if (p == path || p[-1] == '/')
-				return -1;
-		}
-	}
-
-	return 0;
-}
-
 static int tftp_send_error(int sock, enum tftp_error code, const char *msg)
 {
 	size_t len;

--- a/translate.c
+++ b/translate.c
@@ -179,13 +179,6 @@ static int translate_readwrite(const char *file, int flags)
 	int ret;
 	int fd;
 
-	/* Reject directory traversal attempts */
-	if (strstr(file, "..")) {
-		warn("path traversal attempt rejected: %s", file);
-		errno = EACCES;
-		return -1;
-	}
-
 	ret = mkdir(TQFTPSERV_RW_DIR, 0700);
 	if (ret < 0 && errno != EEXIST) {
 		warn("failed to create tqftpserv readwrite directory");
@@ -207,6 +200,33 @@ static int translate_readwrite(const char *file, int flags)
 }
 
 /**
+ * sanitize_path() - check a requested path for directory traversal
+ * @path:	path to check
+ *
+ * Rejects any ".." path component, whether leading, in the middle or
+ * trailing. Applied uniformly to every namespace served.
+ *
+ * Return: 0 if the path is safe, -1 if it attempts traversal
+ */
+int sanitize_path(const char *path)
+{
+	const char *p = path;
+
+	while (*p) {
+		if (p[0] == '.' && p[1] == '.' &&
+		    (p[2] == '/' || p[2] == '\0'))
+			return -1;
+
+		p = strchr(p, '/');
+		if (!p)
+			break;
+		p++;
+	}
+
+	return 0;
+}
+
+/**
  * translate_open() - open file after translating path
  *
  * Strips /readonly/firmware/image/ and searches among remoteproc firmware.
@@ -218,6 +238,12 @@ static int translate_readwrite(const char *file, int flags)
  */
 int translate_open(const char *path, int flags)
 {
+	if (sanitize_path(path) < 0) {
+		warnx("path traversal attempt rejected: %s", path);
+		errno = EACCES;
+		return -1;
+	}
+
 	if (!strncmp(path, READONLY_PATH, strlen(READONLY_PATH)))
 		return translate_readonly(path + strlen(READONLY_PATH));
 	else if (!strncmp(path, READONLY_MODEM_PATH, strlen(READONLY_MODEM_PATH)))

--- a/translate.c
+++ b/translate.c
@@ -204,7 +204,13 @@ static int translate_readwrite(const char *file, int flags)
  * @path:	path to check
  *
  * Rejects any ".." path component, whether leading, in the middle or
- * trailing. Applied uniformly to every namespace served.
+ * trailing. Also rejects an empty path component (a "//" sequence): once
+ * the namespace prefix is stripped, a leading slash in the remainder
+ * would turn the openat(2) in translate_readwrite() into an absolute
+ * open that escapes the readwrite directory (e.g. "/readwrite//etc/passwd"
+ * strips to "/etc/passwd"). Requests are always absolute, so a single
+ * leading slash is expected and allowed; every interior component must be
+ * non-empty. Applied uniformly to every namespace served.
  *
  * Return: 0 if the path is safe, -1 if it attempts traversal
  */
@@ -212,7 +218,15 @@ int sanitize_path(const char *path)
 {
 	const char *p = path;
 
+	/* Requests are absolute; consume the expected single leading slash. */
+	if (*p == '/')
+		p++;
+
 	while (*p) {
+		/* Empty component ("//"): would yield an absolute openat path. */
+		if (*p == '/')
+			return -1;
+
 		if (p[0] == '.' && p[1] == '.' &&
 		    (p[2] == '/' || p[2] == '\0'))
 			return -1;

--- a/translate.h
+++ b/translate.h
@@ -1,6 +1,7 @@
 #ifndef __TRANSLATE_H__
 #define __TRANSLATE_H__
 
+int sanitize_path(const char *path);
 int translate_open(const char *path, int flags);
 
 #endif


### PR DESCRIPTION
The path-traversal defence had grown two different, inconsistent rules
across the read-only and read-write namespaces, with the read-only path
relying entirely on the caller to remember to check. That asymmetry is
exactly the kind that becomes an escape the next time the code is
touched. Worse, because the read-write target is opened relative to its
directory with openat(2), a request that collapsed to an absolute path
after prefix stripping could leave the sandbox entirely and write an
arbitrary file. Both are consolidated into a single validation applied
uniformly at the shared chokepoint.

Option negotiation also conflated "option requested with value 0" with
"option not requested", so a stat-style query against an empty file and
an explicit zero seek were silently dropped from the OACK instead of
being acknowledged.

The remaining fixes are the memory-safety hardening: bounds on ERROR-message termination, a checked client
allocation, and a minimum-length guard on session sockets.
