### PR TITLE
add support for `unlink` option

### DIFF
--- a/tqftpserv.c
+++ b/tqftpserv.c
@@ -325,7 +325,7 @@ static int tftp_send_oack(int sock, size_t *blocksize, size_t *tsize,
 
 static int parse_options(const char *buf, size_t len, size_t *blksize,
 			 ssize_t *tsize, size_t *wsize, unsigned int *timeoutms,
-			 size_t *rsize, off_t *seek)
+			 size_t *rsize, off_t *seek, bool *do_unlink)
 {
 	const char *opt, *value;
 	long long parsed_val;
@@ -421,6 +421,20 @@ static int parse_options(const char *buf, size_t len, size_t *blksize,
 				return -1;
 			}
 			*seek = (off_t)parsed_val;
+		} else if (!strcmp(opt, "unlink")) {
+			if (!do_unlink) {
+				log_err("Unlink option used in an RRQ\n");
+				return -1;
+			}
+
+			errno = 0;
+			parsed_val = strtoll(value, &endptr, 10);
+			if (errno != 0 || *endptr != '\0') {
+				log_err("Invalid unlink value '%s'\n", value);
+				return -1;
+			}
+
+			*do_unlink = parsed_val != 0;
 		} else {
 			log_err("Ignoring unknown option '%s' with value '%s'\n", opt, value);
 		}
@@ -489,7 +503,7 @@ static void handle_rrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	if (p < buf + len) {
 		do_oack = true;
 		ret = parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
-				    &timeoutms, &rsize, &seek);
+				    &timeoutms, &rsize, &seek, NULL);
 		if (ret < 0) {
 			log_err("Invalid options in RRQ, rejecting\n");
 			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG, "Option negotiation failed");
@@ -587,6 +601,57 @@ out_close_sock:
 	close(sock);
 }
 
+static void handle_unlink(const char *filename, struct sockaddr_qrtr *sq)
+{
+	enum tftp_error code;
+	const char *msg;
+	int sock;
+	int ret;
+
+	ret = unlink(filename);
+	if (ret < 0) {
+		log_err("unable to unlink %s (%d)\n", filename, errno);
+
+		switch (errno) {
+		case ENOENT:
+			code = TFTP_ERROR_ENOENT;
+			msg = "file not found";
+			break;
+		case EACCES:
+		case EPERM:
+			code = TFTP_ERROR_EACCESS;
+			msg = "Access violation";
+			break;
+		default:
+			code = TFTP_ERROR_UNDEF;
+			msg = strerror(errno);
+			break;
+		}
+
+		tftp_send_error_to(sq, code, msg);
+		return;
+	}
+
+	log_info("%s unlinked by request from %d:%d\n", filename, sq->sq_node, sq->sq_port);
+
+	sock = qrtr_open(0);
+	if (sock < 0) {
+		log_err("unable to create new qrtr socket, reject\n");
+		return;
+	}
+
+	ret = connect(sock, (struct sockaddr *)sq, sizeof(*sq));
+	if (ret < 0) {
+		log_err("unable to connect new qrtr socket to remote\n");
+		close(sock);
+		return;
+	}
+
+	/* Acknowledge the unlink with a plain OACK, no options negotiated. */
+	tftp_send_oack(sock, NULL, NULL, NULL, NULL, NULL, NULL);
+	close(sock);
+}
+
 static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 {
 	struct tftp_client *client;
@@ -602,6 +667,7 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	size_t wsize = 1;
 	off_t seek = 0;
 	bool do_oack = false;
+	bool do_unlink = false;
 	int sock;
 	int ret;
 	int fd;
@@ -649,12 +715,17 @@ static void handle_wrq(const char *buf, size_t len, struct sockaddr_qrtr *sq)
 	if (p < buf + len) {
 		do_oack = true;
 		ret = parse_options(p, len - (p - buf), &blksize, &tsize, &wsize,
-				    &timeoutms, &rsize, &seek);
+				    &timeoutms, &rsize, &seek, &do_unlink);
 		if (ret < 0) {
 			log_err("Invalid options in WRQ, rejecting\n");
 			tftp_send_error_to(sq, TFTP_ERROR_EOPTNEG, "Option negotiation failed");
 			return;
 		}
+	}
+
+	if (do_unlink) {
+		handle_unlink(filename, sq);
+		return;
 	}
 
 	fd = translate_open(filename, O_WRONLY | O_CREAT);


### PR DESCRIPTION
My device based on SM8450 use `unlink` option, but it didn`t supported

`tqftpserv[2433]: Ignoring unknown option 'unlink' with value '0'`

This patch add support for it.

When i analyzed tftp_server binary in ghidra i found it (it`s not full code but enough to get know how it works)

```
void tftp_thread_unlink_handler(long param_1)

{
  int iVar1;
  char *pcVar2;
  int extraout_w8;
  int iVar3;
  
  if (*(long *)(param_1 + 0xa50) == 0) {
    fprintf(_stdout,"\n\nASSERT : Line=%d : Cond=%s\n\n",0x61b,"proto->rx_pkt != NULL");
  }
  if (*(long *)(param_1 + 0xa50) == 0) {
    tftp_log_msg("vendor/qcom/proprietary/tftp/server/src/tftp_server.c",0x61e,0,"rx_pkt is NULL.\n"
                );
  }
  else if (*(int *)(*(long *)(param_1 + 0xa50) + 0x1e0c) == 2) {
    iVar1 = tftp_connection_set_timeout(param_1 + 0x8c0,*(undefined4 *)(param_1 + 0x858));
    if (iVar1 == 0) {
      iVar1 = tftp_os_unlink(param_1 + 0x429);
      if (iVar1 < 0) {
        iVar3 = -iVar1;
        if (SBORROW4(0,iVar1)) {
          __ubsan_handle_negate_overflow_minimal_abort();
          iVar3 = extraout_w8;
        }
        pcVar2 = strerror(iVar1);
        tftp_log_msg("vendor/qcom/proprietary/tftp/server/src/tftp_server.c",0x642,0,
                     "unlink failed [%d] [%s]",iVar1,pcVar2);
        tftp_protocol_send_errno_as_error_packet(param_1 + 0x850,iVar3);
      }
      else {
        tftp_log_msg("vendor/qcom/proprietary/tftp/server/src/tftp_server.c",0x647,3,
                     "unlink was success");
        tftp_protocol_server_send_oack_no_wait(param_1 + 0x850);
      }
    }
    else {
      fprintf(_stdout,"\n\nASSERT : Line=%d : Cond=%s\n\n",0x630,
              "connection_open_res == TFTP_CONNECTION_RESULT_SUCCESS");
      tftp_log_msg("vendor/qcom/proprietary/tftp/server/src/tftp_server.c",0x637,0,
                   "Set new timeout failed during unlink. timeout = %u\n",
                   *(undefined4 *)(param_1 + 0x858));
      tftp_protocol_send_error_packet(param_1 + 0x850,0,"Timeout could not be set for unlink");
    }
  }
  else {
    tftp_log_msg("vendor/qcom/proprietary/tftp/server/src/tftp_server.c",0x627,0,
                 "Unlink option used in an RRQ sending error pkt.");
    tftp_protocol_send_error_packet(param_1 + 0x850,4,"Unlink option used in an RRQ");
  }
  return;
}


int tftp_os_unlink(char *param_1)

{
  undefined4 uVar1;
  int *piVar2;
  undefined4 *puVar3;
  char *pcVar4;
  int extraout_w8;
  int local_2c;
  
  local_2c = unlink(param_1);
  if (local_2c != 0) {
    piVar2 = (int *)__errno();
    if (*piVar2 != 2) {
      piVar2 = (int *)__errno();
      local_2c = -*piVar2;
      if (SBORROW4(0,*piVar2)) {
        __ubsan_handle_negate_overflow_minimal_abort();
        local_2c = extraout_w8;
      }
      puVar3 = (undefined4 *)__errno();
      uVar1 = *puVar3;
      piVar2 = (int *)__errno();
      pcVar4 = strerror(*piVar2);
      tftp_log_msg("vendor/qcom/proprietary/tftp/os/src/tftp_os_la.c",0xb2,0,
                   "unlink failed: [%d] [%s] [%s]",uVar1,param_1,pcVar4);
    }
  }
  return local_2c;
}

```

