### PR TITLE
tqftpserv-populate-readwrite: add unit to copy files from persist part

### DIFF
--- a/populate-readwrite.sh
+++ b/populate-readwrite.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/sh
+# Populate tqftp readwrite data from persist partition
+
+set -eu
+
+PERSIST_DEV="/dev/disk/by-partlabel/persist"
+PERSIST_MOUNT="/mnt/persist"
+TQFTPSERV_TMP="/var/lib/tqftpserv"
+
+if [ -f $TQFTPSERV_TMP/readwrite_ready ]; then
+	exit 0
+fi
+
+mkdir -p $PERSIST_MOUNT
+mount $PERSIST_DEV -o ro,noatime $PERSIST_MOUNT
+mkdir -p $TQFTPSERV_TMP
+cp -r $PERSIST_MOUNT/rfs/msm/mpss/* $TQFTPSERV_TMP/
+touch $TQFTPSERV_TMP/readwrite_ready
+umount $PERSIST_MOUNT
+rmdir $PERSIST_MOUNT

--- a/tqftpserv-populate-readwrite.service.in
+++ b/tqftpserv-populate-readwrite.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description= Populate tqftp readwrite data from persist partition
+Requires=dev-disk-by\x2dpartlabel-persist.device
+After=dev-disk-by\x2dpartlabel-persist.device
+
+[Service]
+Type=oneshot
+ExecStart=@prefix@/bin/populate-readwrite.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Some devices (motorola-dubai) need to access readwrite files found in the persist partition in `rfs/msm/mpss` to have working modem.

Create a new systemd unit that calls a shell script to copy the files into the readwrite folder (currently /var/lib/tqftpserv). The units runs only if and after /dev/disk/by-partlabel/persist is available.

I tested this on motorola-dubai by installing manually the unit and script.

The APKBUILD will need to be extended to install the new unit and shell script.

I am not sure if we should make the tqftpserv unit depend on the new one, and if this can cause issues on devices without the persist partition.